### PR TITLE
Add support for using i18n.T()

### DIFF
--- a/cmds/checkup.go
+++ b/cmds/checkup.go
@@ -138,6 +138,21 @@ func (cu *Checkup) inspectFile(file string) (translatedStrings []string, err err
 						translatedStrings = append(translatedStrings, translatedString)
 					}
 				}
+			case *ast.SelectorExpr:
+				expr := x.Fun.(*ast.SelectorExpr)
+				if ident, ok := expr.X.(*ast.Ident); ok {
+					funName := expr.Sel.Name
+
+					if ident.Name == "i18n" && (funName == "T" || funName == "t") {
+						if stringArg, ok := x.Args[0].(*ast.BasicLit); ok {
+							translatedString, err := strconv.Unquote(stringArg.Value)
+							if err != nil {
+								panic(err.Error())
+							}
+							translatedStrings = append(translatedStrings, translatedString)
+						}
+					}
+				}
 			default:
 				//Skip!
 			}

--- a/integration/checkup/checkup_test.go
+++ b/integration/checkup/checkup_test.go
@@ -60,6 +60,20 @@ var _ = Describe("checkup", func() {
 		})
 	})
 
+	Context("when the i18n package is fully qualified", func() {
+		BeforeEach(func() {
+			fixturesPath = filepath.Join("..", "..", "test_fixtures", "checkup", "qualified")
+		})
+
+		It("returns 0", func() {
+			Ω(session.ExitCode()).Should(Equal(0))
+		})
+
+		It("prints a reassuring message", func() {
+			Ω(session).Should(Say("OK"))
+		})
+	})
+
 	Context("When there are problems", func() {
 		BeforeEach(func() {
 			fixturesPath = filepath.Join("..", "..", "test_fixtures", "checkup", "notsogood")

--- a/test_fixtures/checkup/qualified/src/code/main.go
+++ b/test_fixtures/checkup/qualified/src/code/main.go
@@ -1,0 +1,11 @@
+package code
+
+import (
+	"fmt"
+
+	"github.com/nicksnyder/go-i18n/i18n"
+)
+
+func main() {
+	fmt.Println(i18n.T("Translated hello world!"))
+}

--- a/test_fixtures/checkup/qualified/translations/en_US.all.json
+++ b/test_fixtures/checkup/qualified/translations/en_US.all.json
@@ -1,0 +1,6 @@
+[
+  {
+    "id": "Translated hello world!",
+    "translation": "Translated hello world!"
+  }
+]

--- a/test_fixtures/checkup/qualified/translations/zh_CN.all.json
+++ b/test_fixtures/checkup/qualified/translations/zh_CN.all.json
@@ -1,0 +1,6 @@
+[
+  {
+    "id": "Translated hello world!",
+    "translation": "你好世界!"
+  }
+]


### PR DESCRIPTION
The current assumption is that i18n will be dot imported and the T() func used directly.

Using dot imports in production code is an error per golint: https://github.com/golang/lint/blob/master/lint.go#L443

Because checkup walks the AST searching for calls to T() to determine if there is a translation present, switching to i18n.T() fails. This change allows checkup to include i18n.T() calls.

This does add a case to the switch statement which is mostly a duplicate of the above statement's logic, but it's simple enough that @simonleung8  and I decided that the alternative was far less readable.