### PR TITLE
add substring match option to extract-strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ The general usage for `-c extract-strings` command is:
   -c extract-strings         the extract strings command
 
   -e                         [optional] the JSON file with strings to be excluded, defaults to excluded.json if present
+	-s												 [optional] the JSON file with regexp that specify a capturing group to be extracted instead of the full string matching the regexp
 
   --po                       to generate standard .po files for translation
   --meta                     [optional] create a *.extracted.json file with metadata such as: filename, directory, and positions of the strings in source file

--- a/common/cmd.go
+++ b/common/cmd.go
@@ -20,9 +20,10 @@ type Options struct {
 	OutputMatchPackageFlag bool
 	OutputFlatFlag         bool
 
-	ExcludedFilenameFlag string
-	FilenameFlag         string
-	DirnameFlag          string
+	ExcludedFilenameFlag  string
+	SubstringFilenameFlag string
+	FilenameFlag          string
+	DirnameFlag           string
 
 	RecurseFlag bool
 

--- a/i18n4go/i18n4go.go
+++ b/i18n4go/i18n4go.go
@@ -227,6 +227,8 @@ func init() {
 
 	flag.StringVar(&options.ExcludedFilenameFlag, "e", "excluded.json", "[optional] the excluded JSON file name, all strings there will be excluded")
 
+	flag.StringVar(&options.SubstringFilenameFlag, "s", "capturing_group.json", "[optional] the substring capturing JSON file name, all strings there will only have their first capturing group saved as a translation")
+
 	flag.StringVar(&options.OutputDirFlag, "o", "", "output directory where the translation files will be placed")
 
 	flag.BoolVar(&options.OutputFlatFlag, "output-flat", true, "generated files are created in the specified output directory")
@@ -281,6 +283,7 @@ usage: i18n4go -c checkup
 
   --po                       to generate standard .po files for translation
   -e                         [optional] the JSON file with strings to be excluded, defaults to excluded.json if present
+	-s												 [optional] the JSON file with regexp that specify a capturing group to be extracted instead of the full string matching the regexp
   --meta                     [optional] create a *.extracted.json file with metadata such as: filename, directory, and positions of the strings in source file
   --dry-run                  [optional] prevents any output files from being created
 

--- a/integration/extract_strings/s_option_test.go
+++ b/integration/extract_strings/s_option_test.go
@@ -1,0 +1,61 @@
+package extract_strings_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	. "github.com/maximilien/i18n4go/integration/test_helpers"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("extract-strings -s filePath", func() {
+	var (
+		outputPath            string
+		fixturesPath          string
+		inputFilesPath        string
+		expectedFilesPath     string
+		matchingGroupFilePath string
+	)
+
+	BeforeEach(func() {
+		_, err := os.Getwd()
+		Ω(err).ShouldNot(HaveOccurred())
+
+		outputPath, err = ioutil.TempDir("", "i18n4go4go")
+		Ω(err).ToNot(HaveOccurred())
+
+		fixturesPath = filepath.Join("..", "..", "test_fixtures", "extract_strings")
+		inputFilesPath = filepath.Join(fixturesPath, "s_option", "input_files", "app", "app.go")
+		expectedFilesPath = filepath.Join(fixturesPath, "s_option", "expected_output")
+		matchingGroupFilePath = filepath.Join(fixturesPath, "s_option", "input_files", "matching_group.json")
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(outputPath)
+	})
+
+	Context("When i18n4go4go is run with the -s flag", func() {
+		BeforeEach(func() {
+			session := Runi18n("-c", "extract-strings", "-v", "-f", inputFilesPath, "-o", outputPath, "-s", matchingGroupFilePath)
+
+			Ω(session.ExitCode()).Should(Equal(0))
+		})
+
+		It("use the regexFile to parse substring", func() {
+			expectedFilePath := filepath.Join(expectedFilesPath, "app.go.en.json")
+			actualFilePath := filepath.Join(outputPath, "app.go.en.json")
+
+			expectedBytes, err := ioutil.ReadFile(expectedFilePath)
+			Ω(err).Should(BeNil())
+			Ω(expectedBytes).ShouldNot(BeNil())
+
+			actualBytes, err := ioutil.ReadFile(actualFilePath)
+			Ω(err).Should(BeNil())
+			Ω(actualBytes).ShouldNot(BeNil())
+
+			Ω(string(expectedBytes)).Should(MatchJSON(string(actualBytes)))
+		})
+	})
+})

--- a/test_fixtures/extract_strings/s_option/expected_output/app.go.en.json
+++ b/test_fixtures/extract_strings/s_option/expected_output/app.go.en.json
@@ -1,0 +1,12 @@
+[
+   {
+      "id": "a string",
+      "translation": "a string",
+      "modified": false
+   },
+   {
+      "id": "show the app details",
+      "translation": "show the app details",
+      "modified": false
+   }
+]

--- a/test_fixtures/extract_strings/s_option/input_files/app/app.go
+++ b/test_fixtures/extract_strings/s_option/input_files/app/app.go
@@ -1,0 +1,16 @@
+package main
+
+import "fmt"
+
+func main() {
+	s := "a string"
+	fmt.Println(s)
+	newStruct := mystruct{
+		mystring: s,
+	}
+	fmt.Println(newStruct.mystring)
+}
+
+type mystruct struct {
+	mystring string `command:"app" description:"show the app details"`
+}

--- a/test_fixtures/extract_strings/s_option/input_files/matching_group.json
+++ b/test_fixtures/extract_strings/s_option/input_files/matching_group.json
@@ -1,0 +1,5 @@
+{
+  "captureGroupSubstrings": [
+    "`.*description:\"(.*)\".*`"
+  ]
+}


### PR DESCRIPTION
New flag to extract-strings command that allows the user to create an
optional file of regular expressions with a single capture group each
that is used as a filter to only extract the given capture group.