### PR TITLE
chore: Update golang to 1.18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.2
+  - 1.18
 before_install:
 - go get github.com/onsi/ginkgo/...
 - go get github.com/onsi/gomega/...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximilien/i18n4go
 
-go 1.17
+go 1.18
 
 require (
 	github.com/nicksnyder/go-i18n v1.4.0

--- a/i18n4go/i18n4go.go
+++ b/i18n4go/i18n4go.go
@@ -13,7 +13,7 @@ import (
 	"github.com/maximilien/i18n4go/common"
 )
 
-const VERSION = "v0.3.4"
+const VERSION = "v1.3.4"
 
 var options common.Options
 


### PR DESCRIPTION
# Context

The repo is using a very old version of golang and we should look into updating to the latest if possible. This PR will remove the vendor files in favor of go modules via the `go.mod` file. 
