### PR TITLE
build(github_action): Set GOPATH env before any Go step

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -36,4 +36,6 @@ jobs:
       run: ./bin/build
 
     - name: Test
-      run: ./bin/test
+      run: |
+        export GOPATH=$(go env GOPATH)/bin
+        ./bin/test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,6 +11,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    steps:
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v3
       with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,10 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-
+    - name: Setup env 
+      run: |
+        echo "::set-env name=GOPATH::$(go env GOPATH)"
+        echo "::add-path::$(go env GOPATH)/bin"
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,8 +14,8 @@ jobs:
     steps:
     - name: Setup env 
       run: |
-        echo "::set-env name=GOPATH::$(go env GOPATH)"
-        echo "::add-path::$(go env GOPATH)/bin"
+        echo "GOPATH=$(go env GOPATH)" >> $GOPATH
+        echo "$(go env GOPATH)/bin" >> $PATH
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,18 +11,13 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    steps:
-    - name: Setup env 
-      run: |
-        echo "GOPATH=$(go env GOPATH)" >> $GOPATH
-        echo "$(go env GOPATH)/bin" >> $PATH
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
-        go-version: ^1.13
+        go-version: '>=1.17'
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Get dependencies
       run: |


### PR DESCRIPTION
# Context

After upgrading to the go@^1.17, GitHub actions is having trouble building and running the test/linter. To fix this issue, this PR will setup the GOPATH before running any go related stages.


