### PR TITLE
build: Fixed export GOPATH and continue build if greetings action fails

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,5 +37,5 @@ jobs:
 
     - name: Test
       run: |
-        export GOPATH=$(pwd):$(go env GOPATH)/bin
+        export GOPATH=$(go env GOPATH)/bin
         ./bin/test

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/first-interaction@v1
+      continue-on-error: true
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         issue-message: 'Thanks for your contribution. Please contact me @maximilien to ensure follow-up.'


### PR DESCRIPTION
# Context

- There is an [ongoing issue](https://github.com/actions/first-interaction/issues/101) with the greetings.yml GitHub action. Since the action is not critical, I added a condition to continue build on failure. 