### PR TITLE
Cobra "fashion" first pass

### DIFF
--- a/cmds/checkup.go
+++ b/cmds/checkup.go
@@ -30,7 +30,7 @@ func NewCheckup(options common.Options) Checkup {
 	}
 }
 
-// NewVersionCommand implements 'i18n checkup' command
+// NewCheckupCommand implements 'i18n checkup' command
 func NewCheckupCommand(p *cobra.Params, options common.Options) *cobra.Command {
 	checkupCmd := &cobra.Command{
 		Use:   "checkup",

--- a/cmds/checkup.go
+++ b/cmds/checkup.go
@@ -12,6 +12,8 @@ import (
 	"go/parser"
 	"go/token"
 
+	"github.com/spf13/cobra"
+	
 	"github.com/maximilien/i18n4go/common"
 )
 
@@ -26,6 +28,21 @@ func NewCheckup(options common.Options) Checkup {
 		options:         options,
 		I18nStringInfos: []common.I18nStringInfo{},
 	}
+}
+
+// NewVersionCommand implements 'i18n checkup' command
+func NewVersionCommand(p *cobra.Params, options common.Options) *cobra.Command {
+	checkupCmd := &cobra.Command{
+		Use:   "checkup",
+		Short: "Checks the transated files",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return NewCheckup(options).Run()
+		},
+	}
+
+	// TODO: setup options and params for Cobra command here using common.Options
+	
+	return checkupCmd
 }
 
 func (cu *Checkup) Options() common.Options {

--- a/cmds/checkup.go
+++ b/cmds/checkup.go
@@ -14,7 +14,7 @@ import (
 	"go/token"
 
 	"github.com/spf13/cobra"
-	
+
 	"github.com/maximilien/i18n4go/common"
 )
 
@@ -25,8 +25,8 @@ type Checkup struct {
 	IgnoreRegexp    *regexp.Regexp
 }
 
-func NewCheckup(options common.Options) Checkup {
-	return Checkup{
+func NewCheckup(options common.Options) *Checkup {
+	return &Checkup{
 		options:         options,
 		I18nStringInfos: []common.I18nStringInfo{},
 		IgnoreRegexp:    common.GetIgnoreRegexp(options.IgnoreRegexpFlag),
@@ -34,7 +34,7 @@ func NewCheckup(options common.Options) Checkup {
 }
 
 // NewCheckupCommand implements 'i18n checkup' command
-func NewCheckupCommand(p *cobra.Params, options common.Options) *cobra.Command {
+func NewCheckupCommand(p *I18NParams, options common.Options) *cobra.Command {
 	checkupCmd := &cobra.Command{
 		Use:   "checkup",
 		Short: "Checks the transated files",
@@ -44,7 +44,7 @@ func NewCheckupCommand(p *cobra.Params, options common.Options) *cobra.Command {
 	}
 
 	// TODO: setup options and params for Cobra command here using common.Options
-	
+
 	return checkupCmd
 }
 

--- a/cmds/checkup.go
+++ b/cmds/checkup.go
@@ -31,7 +31,7 @@ func NewCheckup(options common.Options) Checkup {
 }
 
 // NewVersionCommand implements 'i18n checkup' command
-func NewVersionCommand(p *cobra.Params, options common.Options) *cobra.Command {
+func NewCheckupCommand(p *cobra.Params, options common.Options) *cobra.Command {
 	checkupCmd := &cobra.Command{
 		Use:   "checkup",
 		Short: "Checks the transated files",

--- a/cmds/create_translations.go
+++ b/cmds/create_translations.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"path/filepath"
-	
+
 	"github.com/spf13/cobra"
 
 	"github.com/maximilien/i18n4go/common"
@@ -44,10 +44,10 @@ type GoogleTranslateTranslation struct {
 	DetectedSourceLanguage string `json:"detectedSourceLanguage"`
 }
 
-func NewCreateTranslations(options common.Options) createTranslations {
+func NewCreateTranslations(options common.Options) *createTranslations {
 	languages := common.ParseStringList(options.LanguagesFlag, ",")
 
-	return createTranslations{options: options,
+	return &createTranslations{options: options,
 		Filename:       options.FilenameFlag,
 		OutputDirname:  options.OutputDirFlag,
 		SourceLanguage: options.SourceLanguageFlag,
@@ -57,7 +57,7 @@ func NewCreateTranslations(options common.Options) createTranslations {
 }
 
 // NewCreateTranslationsCommand implements 'i18n create-translations' command
-func NewCreateTranslationsCommand(p *cobra.Params, options common.Options) *cobra.Command {
+func NewCreateTranslationsCommand(p *I18NParams, options common.Options) *cobra.Command {
 	createTranslationsCmd := &cobra.Command{
 		Use:   "create-translations",
 		Short: "Creates the transation files",
@@ -67,7 +67,7 @@ func NewCreateTranslationsCommand(p *cobra.Params, options common.Options) *cobr
 	}
 
 	// TODO: setup options and params for Cobra command here using common.Options
-	
+
 	return createTranslationsCmd
 }
 

--- a/cmds/create_translations.go
+++ b/cmds/create_translations.go
@@ -56,7 +56,7 @@ func NewCreateTranslations(options common.Options) createTranslations {
 		TotalFiles:     0}
 }
 
-// NewVersionCommand implements 'i18n checkup' command
+// NewCreateTranslationsCommand implements 'i18n checkup' command
 func NewCreateTranslationsCommand(p *cobra.Params, options common.Options) *cobra.Command {
 	createTranslationsCmd := &cobra.Command{
 		Use:   "create-translations",

--- a/cmds/create_translations.go
+++ b/cmds/create_translations.go
@@ -56,7 +56,7 @@ func NewCreateTranslations(options common.Options) createTranslations {
 		TotalFiles:     0}
 }
 
-// NewCreateTranslationsCommand implements 'i18n checkup' command
+// NewCreateTranslationsCommand implements 'i18n create-translations' command
 func NewCreateTranslationsCommand(p *cobra.Params, options common.Options) *cobra.Command {
 	createTranslationsCmd := &cobra.Command{
 		Use:   "create-translations",

--- a/cmds/create_translations.go
+++ b/cmds/create_translations.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"net/url"
 	"path/filepath"
+	
+	"github.com/spf13/cobra"
 
 	"github.com/maximilien/i18n4go/common"
 )
@@ -52,6 +54,21 @@ func NewCreateTranslations(options common.Options) createTranslations {
 		Languages:      languages,
 		TotalStrings:   0,
 		TotalFiles:     0}
+}
+
+// NewVersionCommand implements 'i18n checkup' command
+func NewCreateTranslationsCommand(p *cobra.Params, options common.Options) *cobra.Command {
+	createTranslationsCmd := &cobra.Command{
+		Use:   "create-translations",
+		Short: "Creates the transation files",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return NewCreateTranslations(options).Run()
+		},
+	}
+
+	// TODO: setup options and params for Cobra command here using common.Options
+	
+	return createTranslationsCmd
 }
 
 func (ct *createTranslations) Options() common.Options {

--- a/cmds/extract_strings.go
+++ b/cmds/extract_strings.go
@@ -17,6 +17,8 @@ import (
 	"encoding/json"
 	"io/ioutil"
 
+	"github.com/spf13/cobra"
+	
 	"github.com/maximilien/i18n4go/common"
 )
 
@@ -65,6 +67,21 @@ func NewExtractStrings(options common.Options) extractStrings {
 		TotalFiles:       0,
 		IgnoreRegexp:     compiledRegexp,
 	}
+}
+
+// NewExtractTranslationsCommand implements 'i18n extract-translations' command
+func NewExtractTranslationsCommand(p *cobra.Params, options common.Options) *cobra.Command {
+	extractTranslationsCmd := &cobra.Command{
+		Use:   "extract-translations",
+		Short: "Extract the transation files",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return NewExtractTranslations(options).Run()
+		},
+	}
+
+	// TODO: setup options and params for Cobra command here using common.Options
+	
+	return extractTranslationsCmd
 }
 
 func (es *extractStrings) Options() common.Options {

--- a/cmds/extract_strings.go
+++ b/cmds/extract_strings.go
@@ -18,7 +18,7 @@ import (
 	"io/ioutil"
 
 	"github.com/spf13/cobra"
-	
+
 	"github.com/maximilien/i18n4go/common"
 )
 
@@ -45,9 +45,8 @@ type extractStrings struct {
 	IgnoreRegexp *regexp.Regexp
 }
 
-func NewExtractStrings(options common.Options) extractStrings {
-
-	return extractStrings{options: options,
+func NewExtractStrings(options common.Options) *extractStrings {
+	return &extractStrings{options: options,
 		Filename:         "extracted_strings.json",
 		OutputDirname:    options.OutputDirFlag,
 		ExtractedStrings: nil,
@@ -61,18 +60,18 @@ func NewExtractStrings(options common.Options) extractStrings {
 	}
 }
 
-// NewExtractTranslationsCommand implements 'i18n extract-translations' command
-func NewExtractTranslationsCommand(p *cobra.Params, options common.Options) *cobra.Command {
+// NewExtractStringsCommand implements 'i18n extract-translations' command
+func NewExtractStringsCommand(p *I18NParams, options common.Options) *cobra.Command {
 	extractTranslationsCmd := &cobra.Command{
 		Use:   "extract-translations",
 		Short: "Extract the transation files",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return NewExtractTranslations(options).Run()
+			return NewExtractStrings(options).Run()
 		},
 	}
 
 	// TODO: setup options and params for Cobra command here using common.Options
-	
+
 	return extractTranslationsCmd
 }
 

--- a/cmds/fixup.go
+++ b/cmds/fixup.go
@@ -16,11 +16,11 @@ import (
 	"go/token"
 
 	"github.com/spf13/cobra"
-	
+
 	"github.com/maximilien/i18n4go/common"
 )
 
-type Fixup struct {
+type fixup struct {
 	options common.Options
 
 	I18nStringInfos []common.I18nStringInfo
@@ -30,8 +30,8 @@ type Fixup struct {
 	IgnoreRegexp    *regexp.Regexp
 }
 
-func NewFixup(options common.Options) Fixup {
-	return Fixup{
+func NewFixup(options common.Options) *fixup {
+	return &fixup{
 		options:         options,
 		I18nStringInfos: []common.I18nStringInfo{},
 		IgnoreRegexp:    common.GetIgnoreRegexp(options.IgnoreRegexpFlag),
@@ -39,7 +39,7 @@ func NewFixup(options common.Options) Fixup {
 }
 
 // NewFixupCommand implements 'i18n fixup' command
-func NewFixupCommand(p *cobra.Params, options common.Options) *cobra.Command {
+func NewFixupCommand(p *I18NParams, options common.Options) *cobra.Command {
 	fixupCmd := &cobra.Command{
 		Use:   "fixup",
 		Short: "Fixup the transation files",
@@ -49,15 +49,15 @@ func NewFixupCommand(p *cobra.Params, options common.Options) *cobra.Command {
 	}
 
 	// TODO: setup options and params for Cobra command here using common.Options
-	
+
 	return fixupCmd
 }
 
-func (fix *Fixup) Options() common.Options {
+func (fix *fixup) Options() common.Options {
 	return fix.options
 }
 
-func (fix *Fixup) Println(a ...interface{}) (int, error) {
+func (fix *fixup) Println(a ...interface{}) (int, error) {
 	if fix.options.VerboseFlag {
 		return fmt.Println(a...)
 	}
@@ -65,7 +65,7 @@ func (fix *Fixup) Println(a ...interface{}) (int, error) {
 	return 0, nil
 }
 
-func (fix *Fixup) Printf(msg string, a ...interface{}) (int, error) {
+func (fix *fixup) Printf(msg string, a ...interface{}) (int, error) {
 	if fix.options.VerboseFlag {
 		return fmt.Printf(msg, a...)
 	}
@@ -73,7 +73,7 @@ func (fix *Fixup) Printf(msg string, a ...interface{}) (int, error) {
 	return 0, nil
 }
 
-func (fix *Fixup) Run() error {
+func (fix *fixup) Run() error {
 	//FIND PROBLEMS HERE AND RETURN AN ERROR
 	source, err := fix.findSourceStrings()
 	fix.Source = source
@@ -219,7 +219,7 @@ func (fix *Fixup) Run() error {
 	return err
 }
 
-func (fix *Fixup) inspectFile(file string) (translatedStrings []string, err error) {
+func (fix *fixup) inspectFile(file string) (translatedStrings []string, err error) {
 	fset := token.NewFileSet()
 	astFile, err := parser.ParseFile(fset, file, nil, parser.AllErrors)
 	if err != nil {
@@ -253,7 +253,7 @@ func (fix *Fixup) inspectFile(file string) (translatedStrings []string, err erro
 	return
 }
 
-func (fix *Fixup) findSourceStrings() (sourceStrings map[string]int, err error) {
+func (fix *fixup) findSourceStrings() (sourceStrings map[string]int, err error) {
 	sourceStrings = make(map[string]int)
 	files := getGoFiles(".")
 
@@ -272,7 +272,7 @@ func (fix *Fixup) findSourceStrings() (sourceStrings map[string]int, err error) 
 	return
 }
 
-func (fix *Fixup) findI18nStrings(i18nFile string) (i18nStrings map[string]common.I18nStringInfo, err error) {
+func (fix *fixup) findI18nStrings(i18nFile string) (i18nStrings map[string]common.I18nStringInfo, err error) {
 	i18nStrings = make(map[string]common.I18nStringInfo)
 
 	stringInfos, err := common.LoadI18nStringInfos(i18nFile)

--- a/cmds/fixup.go
+++ b/cmds/fixup.go
@@ -14,6 +14,8 @@ import (
 	"go/parser"
 	"go/token"
 
+	"github.com/spf13/cobra"
+	
 	"github.com/maximilien/i18n4go/common"
 )
 
@@ -31,6 +33,23 @@ func NewFixup(options common.Options) Fixup {
 		options:         options,
 		I18nStringInfos: []common.I18nStringInfo{},
 	}
+}
+
+"github.com/spf13/cobra"
+
+// NewFixupCommand implements 'i18n fixup' command
+func NewFixupCommand(p *cobra.Params, options common.Options) *cobra.Command {
+	fixupCmd := &cobra.Command{
+		Use:   "fixup",
+		Short: "Fixup the transation files",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return NewFixup(options).Run()
+		},
+	}
+
+	// TODO: setup options and params for Cobra command here using common.Options
+	
+	return fixupCmd
 }
 
 func (fix *Fixup) Options() common.Options {

--- a/cmds/fixup.go
+++ b/cmds/fixup.go
@@ -35,8 +35,6 @@ func NewFixup(options common.Options) Fixup {
 	}
 }
 
-"github.com/spf13/cobra"
-
 // NewFixupCommand implements 'i18n fixup' command
 func NewFixupCommand(p *cobra.Params, options common.Options) *cobra.Command {
 	fixupCmd := &cobra.Command{

--- a/cmds/merge_string.go
+++ b/cmds/merge_string.go
@@ -7,6 +7,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/maximilien/i18n4go/common"
 )
 
@@ -28,6 +30,21 @@ func NewMergeStrings(options common.Options) MergeStrings {
 		SourceLanguage:  options.SourceLanguageFlag,
 		Directory:       options.DirnameFlag,
 	}
+}
+
+// NewMergeStringsCommand implements 'i18n merge-strings' command
+func NewMergeStringsCommand(p *cobra.Params, options common.Options) *cobra.Command {
+	mergeStringsCmd := &cobra.Command{
+		Use:   "merge-strings",
+		Short: "Merge translation strings",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return NewMergeStrings(options).Run()
+		},
+	}
+
+	// TODO: setup options and params for Cobra command here using common.Options
+	
+	return mergeStringsCmd
 }
 
 func (ms *MergeStrings) Options() common.Options {

--- a/cmds/merge_string.go
+++ b/cmds/merge_string.go
@@ -12,7 +12,7 @@ import (
 	"github.com/maximilien/i18n4go/common"
 )
 
-type MergeStrings struct {
+type mergeStrings struct {
 	options common.Options
 
 	I18nStringInfos []common.I18nStringInfo
@@ -22,8 +22,8 @@ type MergeStrings struct {
 	Directory      string
 }
 
-func NewMergeStrings(options common.Options) MergeStrings {
-	return MergeStrings{
+func NewMergeStrings(options common.Options) *mergeStrings {
+	return &mergeStrings{
 		options:         options,
 		I18nStringInfos: []common.I18nStringInfo{},
 		Recurse:         options.RecurseFlag,
@@ -33,7 +33,7 @@ func NewMergeStrings(options common.Options) MergeStrings {
 }
 
 // NewMergeStringsCommand implements 'i18n merge-strings' command
-func NewMergeStringsCommand(p *cobra.Params, options common.Options) *cobra.Command {
+func NewMergeStringsCommand(p *I18NParams, options common.Options) *cobra.Command {
 	mergeStringsCmd := &cobra.Command{
 		Use:   "merge-strings",
 		Short: "Merge translation strings",
@@ -43,15 +43,15 @@ func NewMergeStringsCommand(p *cobra.Params, options common.Options) *cobra.Comm
 	}
 
 	// TODO: setup options and params for Cobra command here using common.Options
-	
+
 	return mergeStringsCmd
 }
 
-func (ms *MergeStrings) Options() common.Options {
+func (ms *mergeStrings) Options() common.Options {
 	return ms.options
 }
 
-func (ms *MergeStrings) Println(a ...interface{}) (int, error) {
+func (ms *mergeStrings) Println(a ...interface{}) (int, error) {
 	if ms.options.VerboseFlag {
 		return fmt.Println(a...)
 	}
@@ -59,7 +59,7 @@ func (ms *MergeStrings) Println(a ...interface{}) (int, error) {
 	return 0, nil
 }
 
-func (ms *MergeStrings) Printf(msg string, a ...interface{}) (int, error) {
+func (ms *mergeStrings) Printf(msg string, a ...interface{}) (int, error) {
 	if ms.options.VerboseFlag {
 		return fmt.Printf(msg, a...)
 	}
@@ -67,11 +67,11 @@ func (ms *MergeStrings) Printf(msg string, a ...interface{}) (int, error) {
 	return 0, nil
 }
 
-func (ms *MergeStrings) Run() error {
+func (ms *mergeStrings) Run() error {
 	return ms.combineStringInfosPerDirectory(ms.Directory)
 }
 
-func (ms *MergeStrings) combineStringInfosPerDirectory(directory string) error {
+func (ms *mergeStrings) combineStringInfosPerDirectory(directory string) error {
 	files, directories := getFilesAndDir(directory)
 	fileList := ms.matchFileToSourceLanguage(files, ms.SourceLanguage)
 
@@ -116,7 +116,7 @@ func getFilesAndDir(dir string) (files []string, dirs []string) {
 	return
 }
 
-func (ms MergeStrings) matchFileToSourceLanguage(files []string, lang string) (list []string) {
+func (ms mergeStrings) matchFileToSourceLanguage(files []string, lang string) (list []string) {
 	languageMatcher := "go." + lang + ".json"
 	for _, file := range files {
 		if strings.Contains(file, languageMatcher) {
@@ -137,15 +137,15 @@ func combineStringInfo(stringInfoList []common.I18nStringInfo, combinedMap map[s
 
 // sort.Interface methods
 
-func (ms *MergeStrings) Len() int {
+func (ms *mergeStrings) Len() int {
 	return len(ms.I18nStringInfos)
 }
 
-func (ms *MergeStrings) Less(i, j int) bool {
+func (ms *mergeStrings) Less(i, j int) bool {
 	return ms.I18nStringInfos[i].ID < ms.I18nStringInfos[j].ID
 }
 
-func (ms *MergeStrings) Swap(i, j int) {
+func (ms *mergeStrings) Swap(i, j int) {
 	tmpI18nStringInfo := ms.I18nStringInfos[i]
 	ms.I18nStringInfos[i] = ms.I18nStringInfos[j]
 	ms.I18nStringInfos[j] = tmpI18nStringInfo

--- a/cmds/rewrite_package.go
+++ b/cmds/rewrite_package.go
@@ -14,6 +14,8 @@ import (
 	"io/ioutil"
 
 	"github.com/maximilien/i18n4go/common"
+	
+	"github.com/spf13/cobra"
 
 	"path/filepath"
 	"strconv"
@@ -86,6 +88,21 @@ func NewRewritePackage(options common.Options) rewritePackage {
 		Recurse:      options.RecurseFlag,
 		IgnoreRegexp: compiledRegexp,
 	}
+}
+
+// NewRewritePackageCommand implements 'i18n rewrite-package' command
+func NewRewritePackageCommand(p *cobra.Params, options common.Options) *cobra.Command {
+	rewritePackageCmd := &cobra.Command{
+		Use:   "rewrite-package",
+		Short: "Rewrite translated packages",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return NewRewritePackage(options).Run()
+		},
+	}
+
+	// TODO: setup options and params for Cobra command here using common.Options
+	
+	return rewritePackageCmd
 }
 
 func (rp *rewritePackage) Options() common.Options {

--- a/cmds/rewrite_package.go
+++ b/cmds/rewrite_package.go
@@ -14,7 +14,7 @@ import (
 	"io/ioutil"
 
 	"github.com/maximilien/i18n4go/common"
-	
+
 	"github.com/spf13/cobra"
 
 	"path/filepath"
@@ -62,7 +62,7 @@ type rewritePackage struct {
 	IgnoreRegexp *regexp.Regexp
 }
 
-func NewRewritePackage(options common.Options) rewritePackage {
+func NewRewritePackage(options common.Options) *rewritePackage {
 	var compiledRegexp *regexp.Regexp
 	if options.IgnoreRegexpFlag != "" {
 		compiledReg, err := regexp.Compile(options.IgnoreRegexpFlag)
@@ -72,7 +72,7 @@ func NewRewritePackage(options common.Options) rewritePackage {
 		compiledRegexp = compiledReg
 	}
 
-	return rewritePackage{options: options,
+	return &rewritePackage{options: options,
 		Filename:                options.FilenameFlag,
 		OutputDirname:           options.OutputDirFlag,
 		I18nStringsFilename:     options.I18nStringsFilenameFlag,
@@ -91,7 +91,7 @@ func NewRewritePackage(options common.Options) rewritePackage {
 }
 
 // NewRewritePackageCommand implements 'i18n rewrite-package' command
-func NewRewritePackageCommand(p *cobra.Params, options common.Options) *cobra.Command {
+func NewRewritePackageCommand(p *I18NParams, options common.Options) *cobra.Command {
 	rewritePackageCmd := &cobra.Command{
 		Use:   "rewrite-package",
 		Short: "Rewrite translated packages",
@@ -101,7 +101,7 @@ func NewRewritePackageCommand(p *cobra.Params, options common.Options) *cobra.Co
 	}
 
 	// TODO: setup options and params for Cobra command here using common.Options
-	
+
 	return rewritePackageCmd
 }
 

--- a/cmds/show_missing_strings.go
+++ b/cmds/show_missing_strings.go
@@ -11,13 +11,13 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	
+
 	"github.com/spf13/cobra"
 
 	"github.com/maximilien/i18n4go/common"
 )
 
-type ShowMissingStrings struct {
+type showMissingStrings struct {
 	options common.Options
 
 	I18nStringInfos     []common.I18nStringInfo
@@ -26,8 +26,8 @@ type ShowMissingStrings struct {
 	Directory           string
 }
 
-func NewShowMissingStrings(options common.Options) ShowMissingStrings {
-	return ShowMissingStrings{
+func NewShowMissingStrings(options common.Options) *showMissingStrings {
+	return &showMissingStrings{
 		options:             options,
 		Directory:           options.DirnameFlag,
 		I18nStringsFilename: options.I18nStringsFilenameFlag,
@@ -36,7 +36,7 @@ func NewShowMissingStrings(options common.Options) ShowMissingStrings {
 }
 
 // NewShowMissingStringsCommand implements 'i18n show-missing-strings' command
-func NewShowMissingStringsCommand(p *cobra.Params, options common.Options) *cobra.Command {
+func NewShowMissingStringsCommand(p *I18NParams, options common.Options) *cobra.Command {
 	showMissingStringsCmd := &cobra.Command{
 		Use:   "show-missing-strings",
 		Short: "Shows missing strings in translations",
@@ -46,15 +46,15 @@ func NewShowMissingStringsCommand(p *cobra.Params, options common.Options) *cobr
 	}
 
 	// TODO: setup options and params for Cobra command here using common.Options
-	
+
 	return showMissingStringsCmd
 }
 
-func (sms *ShowMissingStrings) Options() common.Options {
+func (sms *showMissingStrings) Options() common.Options {
 	return sms.options
 }
 
-func (sms *ShowMissingStrings) Println(a ...interface{}) (int, error) {
+func (sms *showMissingStrings) Println(a ...interface{}) (int, error) {
 	if sms.options.VerboseFlag {
 		return fmt.Println(a...)
 	}
@@ -62,7 +62,7 @@ func (sms *ShowMissingStrings) Println(a ...interface{}) (int, error) {
 	return 0, nil
 }
 
-func (sms *ShowMissingStrings) Printf(msg string, a ...interface{}) (int, error) {
+func (sms *showMissingStrings) Printf(msg string, a ...interface{}) (int, error) {
 	if sms.options.VerboseFlag {
 		return fmt.Printf(msg, a...)
 	}
@@ -70,11 +70,11 @@ func (sms *ShowMissingStrings) Printf(msg string, a ...interface{}) (int, error)
 	return 0, nil
 }
 
-func (sms *ShowMissingStrings) Run() error {
+func (sms *showMissingStrings) Run() error {
 	return sms.showMissingStrings()
 }
 
-func (sms *ShowMissingStrings) showMissingStrings() error {
+func (sms *showMissingStrings) showMissingStrings() error {
 
 	//Load en_US.all.json
 
@@ -100,7 +100,7 @@ func (sms *ShowMissingStrings) showMissingStrings() error {
 	return sms.showExtraStrings()
 }
 
-func (sms *ShowMissingStrings) parseFiles() error {
+func (sms *showMissingStrings) parseFiles() error {
 	sourceFiles, _ := getFilesAndDir(sms.Directory)
 	for _, sourceFile := range sourceFiles {
 		err := sms.inspectFile(sourceFile)
@@ -111,7 +111,7 @@ func (sms *ShowMissingStrings) parseFiles() error {
 
 	return nil
 }
-func (sms *ShowMissingStrings) inspectFile(filename string) error {
+func (sms *showMissingStrings) inspectFile(filename string) error {
 	fset := token.NewFileSet()
 
 	var absFilePath = filename
@@ -138,7 +138,7 @@ func (sms *ShowMissingStrings) inspectFile(filename string) error {
 	return sms.extractString(astFile, fset, filename)
 }
 
-func (sms *ShowMissingStrings) extractString(f *ast.File, fset *token.FileSet, filename string) error {
+func (sms *showMissingStrings) extractString(f *ast.File, fset *token.FileSet, filename string) error {
 	ast.Inspect(f, func(n ast.Node) bool {
 		switch x := n.(type) {
 		case *ast.CallExpr:
@@ -167,7 +167,7 @@ func (sms *ShowMissingStrings) extractString(f *ast.File, fset *token.FileSet, f
 	return nil
 }
 
-func (sms *ShowMissingStrings) showMissingTranslatedStrings() error {
+func (sms *showMissingStrings) showMissingTranslatedStrings() error {
 	missingStrings := false
 	for _, codeString := range sms.TranslatedStrings {
 		if !sms.stringInStringInfos(codeString, sms.I18nStringInfos) {
@@ -188,7 +188,7 @@ func splitFilePathAndString(str string) (string, string) {
 	return splitFileStr[0], splitFileStr[1]
 }
 
-func (sms *ShowMissingStrings) stringInStringInfos(str string, list []common.I18nStringInfo) bool {
+func (sms *showMissingStrings) stringInStringInfos(str string, list []common.I18nStringInfo) bool {
 	_, translatedStr := splitFilePathAndString(str)
 	for _, stringInfo := range list {
 		if translatedStr == stringInfo.ID {
@@ -201,7 +201,7 @@ func (sms *ShowMissingStrings) stringInStringInfos(str string, list []common.I18
 }
 
 // Compares translated strings with strings in codebase.
-func (sms *ShowMissingStrings) showExtraStrings() error {
+func (sms *showMissingStrings) showExtraStrings() error {
 	additionalStrings := false
 	for _, stringInfo := range sms.I18nStringInfos {
 		if !stringInTranslatedStrings(stringInfo.ID, sms.TranslatedStrings) {

--- a/cmds/show_missing_strings.go
+++ b/cmds/show_missing_strings.go
@@ -11,6 +11,8 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	
+	"github.com/spf13/cobra"
 
 	"github.com/maximilien/i18n4go/common"
 )
@@ -31,6 +33,21 @@ func NewShowMissingStrings(options common.Options) ShowMissingStrings {
 		I18nStringsFilename: options.I18nStringsFilenameFlag,
 		TranslatedStrings:   []string{},
 	}
+}
+
+// NewShowMissingStringsCommand implements 'i18n show-missing-strings' command
+func NewShowMissingStringsCommand(p *cobra.Params, options common.Options) *cobra.Command {
+	showMissingStringsCmd := &cobra.Command{
+		Use:   "show-missing-strings",
+		Short: "Shows missing strings in translations",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return NewShowMissingStrings(options).Run()
+		},
+	}
+
+	// TODO: setup options and params for Cobra command here using common.Options
+	
+	return showMissingStringsCmd
 }
 
 func (sms *ShowMissingStrings) Options() common.Options {

--- a/cmds/types.go
+++ b/cmds/types.go
@@ -1,0 +1,12 @@
+package cmds
+
+import (
+	"io"
+)
+
+// I18NParams for creating commands.
+// Useful for inserting mocks for testing
+// and to have common parameters across commands.
+type I18NParams struct {
+	Output io.Writer
+}

--- a/cmds/verify_strings.go
+++ b/cmds/verify_strings.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	
+
 	"github.com/maximilien/i18n4go/common"
 )
 
@@ -21,11 +21,11 @@ type verifyStrings struct {
 	Languages         []string
 }
 
-func NewVerifyStrings(options common.Options) verifyStrings {
+func NewVerifyStrings(options common.Options) *verifyStrings {
 	languageFilenames := common.ParseStringList(options.LanguageFilesFlag, ",")
 	languages := common.ParseStringList(options.LanguagesFlag, ",")
 
-	return verifyStrings{options: options,
+	return &verifyStrings{options: options,
 		InputFilename:     options.FilenameFlag,
 		OutputDirname:     options.OutputDirFlag,
 		LanguageFilenames: languageFilenames,
@@ -35,7 +35,7 @@ func NewVerifyStrings(options common.Options) verifyStrings {
 }
 
 // NewVerifyStringsCommand implements 'i18n verify-strings' command
-func NewVerifyStringsCommand(p *cobra.Params, options common.Options) *cobra.Command {
+func NewVerifyStringsCommand(p *I18NParams, options common.Options) *cobra.Command {
 	verifyStringsCmd := &cobra.Command{
 		Use:   "verify-strings",
 		Short: "Verify strings in translations",
@@ -45,7 +45,7 @@ func NewVerifyStringsCommand(p *cobra.Params, options common.Options) *cobra.Com
 	}
 
 	// TODO: setup options and params for Cobra command here using common.Options
-	
+
 	return verifyStringsCmd
 }
 

--- a/cmds/verify_strings.go
+++ b/cmds/verify_strings.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/spf13/cobra"
+	
 	"github.com/maximilien/i18n4go/common"
 )
 
@@ -30,6 +32,21 @@ func NewVerifyStrings(options common.Options) verifyStrings {
 		Languages:         languages,
 		SourceLanguage:    options.SourceLanguageFlag,
 	}
+}
+
+// NewVerifyStringsCommand implements 'i18n verify-strings' command
+func NewVerifyStringsCommand(p *cobra.Params, options common.Options) *cobra.Command {
+	verifyStringsCmd := &cobra.Command{
+		Use:   "verify-strings",
+		Short: "Verify strings in translations",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return NewVerifyStrings(options).Run()
+		},
+	}
+
+	// TODO: setup options and params for Cobra command here using common.Options
+	
+	return verifyStringsCmd
 }
 
 func (vs *verifyStrings) Options() common.Options {

--- a/cmds/version.go
+++ b/cmds/version.go
@@ -11,7 +11,7 @@ var BuildDate string
 var GitRevision string
 
 // NewVersionCommand implements 'i18n version' command
-func NewVersionCommand(p *cobra.Params) *cobra.Command {
+func NewVersionCommand(p *I18NParams) *cobra.Command {
 	versionCmd := &cobra.Command{
 		Use:   "version",
 		Short: "Show the version of the i18n client",
@@ -22,6 +22,5 @@ func NewVersionCommand(p *cobra.Params) *cobra.Command {
 			return nil
 		},
 	}
-
-  return versionCmd
+	return versionCmd
 }

--- a/cmds/version.go
+++ b/cmds/version.go
@@ -1,0 +1,27 @@
+package cmds
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var Version string
+var BuildDate string
+var GitRevision string
+
+// NewVersionCommand implements 'i18n version' command
+func NewVersionCommand(p *cobra.Params) *cobra.Command {
+	versionCmd := &cobra.Command{
+		Use:   "version",
+		Short: "Show the version of the i18n client",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Printf("Version:      %s\n", Version)
+			fmt.Printf("Build Date:   %s\n", BuildDate)
+			fmt.Printf("Git Revision: %s\n", GitRevision)
+			return nil
+		},
+	}
+
+  return versionCmd
+}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,9 @@ require (
 require (
 	github.com/cloudfoundry/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21 // indirect
 	github.com/golang/protobuf v0.0.0-20160817174113-f592bd283e9e // indirect
+	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/spf13/cobra v1.6.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v2 v2.0.0-20160301204022-a83829b6f129 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,10 @@
 github.com/cloudfoundry/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21 h1:tuijfIjZyjZaHq9xDUh0tNitwXshJpbLkqMOJv4H3do=
 github.com/cloudfoundry/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21/go.mod h1:po7NpZ/QiTKzBKyrsEAxwnTamCoh8uDk/egRpQ7siIc=
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/golang/protobuf v0.0.0-20160817174113-f592bd283e9e h1:NsBEuFdvVJjikQS2+pq88q9LeMNgcCo99Ub1RFB/U1g=
 github.com/golang/protobuf v0.0.0-20160817174113-f592bd283e9e/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
+github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -13,9 +16,16 @@ github.com/onsi/gomega v0.0.0-20160718190435-9ed8da19f215 h1:AKD32Mmgsc6H+N7nb7P
 github.com/onsi/gomega v0.0.0-20160718190435-9ed8da19f215/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/pivotal-cf-experimental/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21 h1:AbOpFa7UXCGaV+aq9tvFdSHEhmcb8uO6nKZdYhKsT1I=
 github.com/pivotal-cf-experimental/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21/go.mod h1:4+wzrM70C+Ky5iZiA6lNV5J48jnGmu8YcbmuVWdlt5s=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
+github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9 h1:nhht2DYV/Sn3qOayu8lM+cU1ii9sTLUeBQwQQfUHtrs=
 golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v2 v2.0.0-20160301204022-a83829b6f129 h1:RBgb9aPUbZ9nu66ecQNIBNsA7j3mB5h8PNDIfhPjaJg=
 gopkg.in/yaml.v2 v2.0.0-20160301204022-a83829b6f129/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This PR adds Cobra to the i18n4go by changing all commands to use Cobra.
All command parameters and structure remain the same. All tests are passing.

Next will be to add to each command the Cobra command fashion by making the -c <commandName> optional and use the command name instead. So for example, instead of: `$i18n4go -c checkup` user can simply do `$i18n4go checkup` etc.