### PR TITLE
refactor(rewrite-trans): Added cobra implementation

### DIFF
--- a/cmds/rewrite_package.go
+++ b/cmds/rewrite_package.go
@@ -90,18 +90,26 @@ func NewRewritePackage(options common.Options) *rewritePackage {
 	}
 }
 
-// NewRewritePackageCommand implements 'i18n rewrite-package' command
-func NewRewritePackageCommand(p *I18NParams, options common.Options) *cobra.Command {
+// NewRewritePackageCommand implements 'i18n4go rewrite-package' command
+func NewRewritePackageCommand(options common.Options) *cobra.Command {
 	rewritePackageCmd := &cobra.Command{
 		Use:   "rewrite-package",
-		Short: "Rewrite translated packages",
+		Short: "Rewrite translated packages from go source files",
+		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			options.FilenameFlag = args[0]
 			return NewRewritePackage(options).Run()
 		},
 	}
 
-	// TODO: setup options and params for Cobra command here using common.Options
-
+	rewritePackageCmd.Flags().BoolVar(&options.PoFlag, "po", false, "generate standard .po file for translation")
+	rewritePackageCmd.Flags().BoolVarP(&options.RecurseFlag, "recursive", "r", false, "recursively rewrite packages from all files in the same directory as filename or dirName")
+	rewritePackageCmd.Flags().StringVarP(&options.DirnameFlag, "directory", "d", "", "the dir name for which all .go files will have their strings extracted")
+	rewritePackageCmd.Flags().StringVar(&options.I18nStringsFilenameFlag, "i18n-strings-filename", "", "a JSON file with the strings that should be i18n enabled, typically the output of the extract-strings command")
+	rewritePackageCmd.Flags().StringVar(&options.I18nStringsDirnameFlag, "i18n-strings-dirname", "", "a directory with the extracted JSON files, using -output-match-package with extract-strings command this directory should match the input files package name")
+	rewritePackageCmd.Flags().StringVarP(&options.OutputDirFlag, "output", "o", "", "output directory where the translation files will be placed")
+	rewritePackageCmd.Flags().StringVar(&options.RootPathFlag, "root-path", "", "the root path to the Go source files whose packages are being rewritten, defaults to working directory, if not specified")
+	rewritePackageCmd.Flags().StringVar(&options.InitCodeSnippetFilenameFlag, "init-code-snippet-filename", "", "[optional] the path to a file containing the template snippet for the code that is used for go-i18n initialization")
 	return rewritePackageCmd
 }
 

--- a/i18n4go/i18n4go.go
+++ b/i18n4go/i18n4go.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/maximilien/i18n4go/cmds"
 	"github.com/maximilien/i18n4go/common"
+	"github.com/spf13/cobra"
 )
 
 const VERSION = "v1.4.0"
@@ -43,8 +44,20 @@ func main() {
 	case "fixup":
 		fixupCmd()
 	default:
-		usage()
+		rootCobraCmd(options)
 	}
+
+}
+
+func rootCobraCmd(opts common.Options) {
+	cmd := &cobra.Command{
+		Use:  "i18n4go",
+		Long: "General purpose tool for i18n",
+	}
+
+	cmd.PersistentFlags().Bool("verbose", false, "verbose mode where lots of output is generated during execution")
+
+	cmd.AddCommand(cmds.NewRewritePackageCommand(opts))
 }
 
 func extractStringsCmd() {


### PR DESCRIPTION
# Context

The purpose of this PR is to refactor the `rewrite-package` subcommand and still maintain the existing behavior by using `-c` to invoke the command.

The framework for maintaining backwards compability is to use the cobra implementation when the `-c` flag is NOT present

