### PR TITLE
refactor(fixup): Added Cobra implementation

### DIFF
--- a/cmds/fixup.go
+++ b/cmds/fixup.go
@@ -53,16 +53,17 @@ func NewFixup(options common.Options) *fixup {
 }
 
 // NewFixupCommand implements 'i18n fixup' command
-func NewFixupCommand(p *I18NParams, options common.Options) *cobra.Command {
+func NewFixupCommand(options common.Options) *cobra.Command {
 	fixupCmd := &cobra.Command{
 		Use:   "fixup",
+		Long:  "Add, update, or remove translation keys from source files and resources files",
 		Short: "Fixup the transation files",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return NewFixup(options).Run()
 		},
 	}
 
-	// TODO: setup options and params for Cobra command here using common.Options
+	fixupCmd.Flags().StringVar(&options.IgnoreRegexpFlag, "ignore-regexp", ".*test.*", "recursively extract strings from all files in the same directory as filename or dirName")
 
 	return fixupCmd
 }

--- a/i18n4go/i18n4go.go
+++ b/i18n4go/i18n4go.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/maximilien/i18n4go/cmds"
 	"github.com/maximilien/i18n4go/common"
+	"github.com/spf13/cobra"
 )
 
 const VERSION = "v1.4.0"
@@ -58,6 +59,24 @@ func main() {
 		fixupCmd()
 	default:
 		usage()
+		rootCobraCmd(options)
+	}
+
+}
+
+func rootCobraCmd(opts common.Options) {
+	cmd := &cobra.Command{
+		Use:  "i18n4go",
+		Long: "General purpose tool for i18n",
+	}
+
+	cmd.PersistentFlags().Bool("verbose", false, "verbose mode where lots of output is generated during execution")
+
+	cmd.AddCommand(cmds.NewFixupCommand(opts))
+
+	if err := cmd.Execute(); err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
# Context

The purpose of this PR is to refactor the `fixup` subcommand and still maintain the existing behavior by using `-c` to invoke the command.

The framework for maintaining backwards compatibility ability is to use the cobra implementation when the `-c` flag is NOT present

