### PR TITLE
refactor(checkup): Added Cobra implementation

### DIFF
--- a/cmds/checkup.go
+++ b/cmds/checkup.go
@@ -47,8 +47,8 @@ func NewCheckup(options common.Options) *Checkup {
 	}
 }
 
-// NewCheckupCommand implements 'i18n checkup' command
-func NewCheckupCommand(p *I18NParams, options common.Options) *cobra.Command {
+// NewCheckupCommand implements 'i18n4go checkup' command
+func NewCheckupCommand(options common.Options) *cobra.Command {
 	checkupCmd := &cobra.Command{
 		Use:   "checkup",
 		Short: "Checks the transated files",
@@ -57,8 +57,9 @@ func NewCheckupCommand(p *I18NParams, options common.Options) *cobra.Command {
 		},
 	}
 
-	// TODO: setup options and params for Cobra command here using common.Options
-
+	checkupCmd.Flags().StringVarP(&options.QualifierFlag, "qualifier", "q", "", "[optional] the qualifier string that is used when using the T(...) function, default to nothing but could be set to `i18n` so that all calls would be: i18n.T(...)")
+	// TODO: Optional flags shouldn't have set defaults. We should look into removing the default
+	checkupCmd.Flags().StringVar(&options.IgnoreRegexpFlag, "ignore-regexp", ".*test.*", "recursively extract strings from all files in the same directory as filename or dirName")
 	return checkupCmd
 }
 

--- a/cmds/checkup.go
+++ b/cmds/checkup.go
@@ -39,16 +39,16 @@ type Checkup struct {
 	IgnoreRegexp    *regexp.Regexp
 }
 
-func NewCheckup(options common.Options) *Checkup {
+func NewCheckup(options *common.Options) *Checkup {
 	return &Checkup{
-		options:         options,
+		options:         *options,
 		I18nStringInfos: []common.I18nStringInfo{},
 		IgnoreRegexp:    common.GetIgnoreRegexp(options.IgnoreRegexpFlag),
 	}
 }
 
 // NewCheckupCommand implements 'i18n4go checkup' command
-func NewCheckupCommand(options common.Options) *cobra.Command {
+func NewCheckupCommand(options *common.Options) *cobra.Command {
 	checkupCmd := &cobra.Command{
 		Use:   "checkup",
 		Short: "Checks the transated files",

--- a/i18n4go/i18n4go.go
+++ b/i18n4go/i18n4go.go
@@ -71,7 +71,7 @@ func rootCobraCmd(opts common.Options) {
 
 	cmd.PersistentFlags().BoolVarP(&opts.VerboseFlag, "verbose", "v", false, "verbose mode where lots of output is generated during execution")
 
-	cmd.AddCommand(cmds.NewCheckupCommand(opts))
+	cmd.AddCommand(cmds.NewCheckupCommand(&opts))
 
 	if err := cmd.Execute(); err != nil {
 		fmt.Println(err.Error())
@@ -206,7 +206,7 @@ func checkupCmd() {
 		return
 	}
 
-	checkup := cmds.NewCheckup(options)
+	checkup := cmds.NewCheckup(&options)
 
 	startTime := time.Now()
 

--- a/i18n4go/i18n4go.go
+++ b/i18n4go/i18n4go.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/maximilien/i18n4go/cmds"
 	"github.com/maximilien/i18n4go/common"
+	"github.com/spf13/cobra"
 )
 
 const VERSION = "v1.4.0"
@@ -57,7 +58,24 @@ func main() {
 	case "fixup":
 		fixupCmd()
 	default:
-		usage()
+		rootCobraCmd(options)
+
+	}
+}
+
+func rootCobraCmd(opts common.Options) {
+	cmd := &cobra.Command{
+		Use:  "i18n4go",
+		Long: "General purpose tool for i18n",
+	}
+
+	cmd.PersistentFlags().BoolVarP(&opts.VerboseFlag, "verbose", "v", false, "verbose mode where lots of output is generated during execution")
+
+	cmd.AddCommand(cmds.NewCheckupCommand(opts))
+
+	if err := cmd.Execute(); err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
# Context

The purpose of this PR is to refactor the `checkup` subcommand and still maintain the existing behavior by using `-c` to invoke the command.

The framework for maintaining backwards compatibility ability is to use the cobra implementation when the `-c` flag is NOT present

