### PR TITLE
refactor: Replaced args with flags to match legacy impl

### DIFF
--- a/cmds/create_translations.go
+++ b/cmds/create_translations.go
@@ -59,12 +59,7 @@ type GoogleTranslateTranslation struct {
 }
 
 func NewCreateTranslations(options *common.Options) *createTranslations {
-	var languages []string
-	if options.LanguagesFlag == "" {
-		languages = options.LanguagesArrayFlag
-	} else {
-		languages = common.ParseStringList(options.LanguagesFlag, ",")
-	}
+	languages := common.ParseStringList(options.LanguagesFlag, ",")
 
 	return &createTranslations{options: *options,
 		Filename:       options.FilenameFlag,
@@ -90,7 +85,8 @@ func NewCreateTranslationsCommand(options *common.Options) *cobra.Command {
 	createTranslationsCmd.Flags().StringVar(&options.GoogleTranslateApiKeyFlag, "google-translate-api-key", "", "[optional] your public Google Translate API key which is used to generate translations (charge is applicable)")
 	createTranslationsCmd.Flags().StringVarP(&options.SourceLanguageFlag, "source-language", "s", "en", "the source language of the file, typically also part of the file name, e.g., \"en_US\"")
 	createTranslationsCmd.Flags().StringVarP(&options.FilenameFlag, "file", "f", "", "the source translation file")
-	createTranslationsCmd.Flags().StringSliceVarP(&options.LanguagesArrayFlag, "languages", "l", []string{}, "a comma separated list of valid languages with optional territory, e.g., \"en, en_US, fr_FR, es\"")
+	createTranslationsCmd.Flags().StringVarP(&options.LanguagesFlag, "languages", "l", "", "a comma separated list of valid languages with optional territory, e.g., \"en, en_US, fr_FR, es\"")
+	createTranslationsCmd.Flags().StringVarP(&options.OutputDirFlag, "output", "o", "", "the output directory where the newly created translation files will be placed")
 
 	return createTranslationsCmd
 

--- a/cmds/extract_strings.go
+++ b/cmds/extract_strings.go
@@ -79,11 +79,7 @@ func NewExtractStringsCommand(options *common.Options) *cobra.Command {
 	extractTranslationsCmd := &cobra.Command{
 		Use:   "extract-strings",
 		Short: "Extract the translation strings from go source files",
-		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// TODO: -f is better suited as an argument since it is required to run the cmd
-			// Need to remove FilenameFlag on refactor
-			options.FilenameFlag = args[0]
 			return NewExtractStrings(options).Run()
 		},
 	}
@@ -91,7 +87,9 @@ func NewExtractStringsCommand(options *common.Options) *cobra.Command {
 	extractTranslationsCmd.Flags().BoolVar(&options.PoFlag, "po", false, "generate standard .po file for translation")
 	// NOTE: To keep existing behavior we are leaving the default value ".*test.*"
 	// but optional flags not used should have default values other than empty or false (for clarity)
+	extractTranslationsCmd.Flags().StringVarP(&options.FilenameFlag, "file", "f", "", "the file name for which strings are extracted")
 	extractTranslationsCmd.Flags().StringVarP(&options.ExcludedFilenameFlag, "exclude", "e", "excluded.json", "the JSON file with strings to be excluded, defaults to excluded.json if present")
+	extractTranslationsCmd.Flags().StringVarP(&options.SubstringFilenameFlag, "substring-file", "s", "capturing_group.json", "the substring capturing JSON file name, all strings there will only have their first capturing group saved as a translation")
 	extractTranslationsCmd.Flags().BoolVarP(&options.MetaFlag, "meta", "m", false, "[optional] create a *.extracted.json file with metadata such as: filename, directory, and positions of the strings in source file")
 	extractTranslationsCmd.Flags().BoolVar(&options.DryRunFlag, "dry-run", false, "prevents any output files from being created")
 	// TODO: Optional flag that defaults to true is not best practice

--- a/cmds/rewrite_package.go
+++ b/cmds/rewrite_package.go
@@ -109,21 +109,22 @@ func NewRewritePackageCommand(options *common.Options) *cobra.Command {
 	rewritePackageCmd := &cobra.Command{
 		Use:   "rewrite-package",
 		Short: "Rewrite translated packages from go source files",
-		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			options.FilenameFlag = args[0]
 			return NewRewritePackage(options).Run()
 		},
 	}
 
 	rewritePackageCmd.Flags().BoolVar(&options.PoFlag, "po", false, "generate standard .po file for translation")
 	rewritePackageCmd.Flags().BoolVarP(&options.RecurseFlag, "recursive", "r", false, "recursively rewrite packages from all files in the same directory as filename or dirName")
+
+	rewritePackageCmd.Flags().StringVarP(&options.FilenameFlag, "file", "f", "", "the source go file to be rewritten")
 	rewritePackageCmd.Flags().StringVarP(&options.DirnameFlag, "directory", "d", "", "the dir name for which all .go files will have their strings extracted")
 	rewritePackageCmd.Flags().StringVar(&options.I18nStringsFilenameFlag, "i18n-strings-filename", "", "a JSON file with the strings that should be i18n enabled, typically the output of the extract-strings command")
 	rewritePackageCmd.Flags().StringVar(&options.I18nStringsDirnameFlag, "i18n-strings-dirname", "", "a directory with the extracted JSON files, using -output-match-package with extract-strings command this directory should match the input files package name")
 	rewritePackageCmd.Flags().StringVarP(&options.OutputDirFlag, "output", "o", "", "output directory where the translation files will be placed")
 	rewritePackageCmd.Flags().StringVar(&options.RootPathFlag, "root-path", "", "the root path to the Go source files whose packages are being rewritten, defaults to working directory, if not specified")
 	rewritePackageCmd.Flags().StringVar(&options.InitCodeSnippetFilenameFlag, "init-code-snippet-filename", "", "[optional] the path to a file containing the template snippet for the code that is used for go-i18n initialization")
+	rewritePackageCmd.Flags().StringVar(&options.IgnoreRegexpFlag, "ignore-regexp", ".*test.*", "a perl-style regular expression for files to ignore, e.g., \".*test.*\"")
 	return rewritePackageCmd
 }
 

--- a/cmds/verify_strings.go
+++ b/cmds/verify_strings.go
@@ -59,7 +59,10 @@ func NewVerifyStringsCommand(options *common.Options) *cobra.Command {
 	}
 
 	verifyStringsCmd.Flags().StringVarP(&options.SourceLanguageFlag, "source-language", "s", "en", "the source language of the file, typically also part of the file name, e.g., \"en_US\"")
-
+	verifyStringsCmd.Flags().StringVar(&options.LanguagesFlag, "languages", "", "a comma separated list of valid languages with optional territory, e.g., \"en, en_US, fr_FR, es\"")
+	verifyStringsCmd.Flags().StringVar(&options.LanguageFilesFlag, "language-files", "", `a comma separated list of target files for different languages to compare,  e.g., \"en, en_US, fr_FR, es\"	                                                                  if not specified then the languages flag is used to find target files in same directory as source`)
+	verifyStringsCmd.Flags().StringVarP(&options.OutputDirFlag, "output", "o", "", "the output directory where the missing translation keys will be placed")
+	verifyStringsCmd.Flags().StringVarP(&options.FilenameFlag, "file", "f", "", "the source translation file")
 	return verifyStringsCmd
 }
 

--- a/common/cmd.go
+++ b/common/cmd.go
@@ -25,10 +25,8 @@ type Options struct {
 	PoFlag      bool
 	MetaFlag    bool
 
-	SourceLanguageFlag string
-	// @deprecated use LanguagesArrayFlag
+	SourceLanguageFlag        string
 	LanguagesFlag             string
-	LanguagesArrayFlag        []string
 	GoogleTranslateApiKeyFlag string
 
 	OutputDirFlag          string

--- a/integration/checkup/checkup_test.go
+++ b/integration/checkup/checkup_test.go
@@ -50,104 +50,213 @@ var _ = Describe("checkup", func() {
 		}
 	})
 
-	Context("When there are no problems", func() {
-		BeforeEach(func() {
-			fixturesPath = filepath.Join("..", "..", "test_fixtures", "checkup", "allgood")
-			err = os.Chdir(fixturesPath)
-			Ω(err).ToNot(HaveOccurred(), "Could not change to fixtures directory")
+	Context("Using legacy commands", func() {
 
-			session = Runi18n("-c", "checkup", "-v")
+		Context("When there are no problems", func() {
+			BeforeEach(func() {
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "checkup", "allgood")
+				err = os.Chdir(fixturesPath)
+				Ω(err).ToNot(HaveOccurred(), "Could not change to fixtures directory")
+
+				session = Runi18n("-c", "checkup", "-v")
+			})
+
+			It("returns 0", func() {
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			It("prints a reassuring message", func() {
+				Ω(session).Should(Say("OK"))
+			})
 		})
 
-		It("returns 0", func() {
-			Ω(session.ExitCode()).Should(Equal(0))
+		Context("when the i18n package is fully qualified", func() {
+			BeforeEach(func() {
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "checkup", "qualified")
+				err = os.Chdir(fixturesPath)
+				Ω(err).ToNot(HaveOccurred(), "Could not change to fixtures directory")
+
+				session = Runi18n("-c", "checkup", "-v", "-q", "i18n")
+			})
+
+			It("returns 0", func() {
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			It("prints a reassuring message", func() {
+				session = Runi18n("-c", "checkup", "-v", "-q", "i18n")
+				Ω(session).Should(Say("OK"))
+			})
 		})
 
-		It("prints a reassuring message", func() {
-			Ω(session).Should(Say("OK"))
+		Context("When the translation files is in format all.<lang>.json", func() {
+			BeforeEach(func() {
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "checkup", "fileformat")
+				err = os.Chdir(fixturesPath)
+				Ω(err).ToNot(HaveOccurred(), "Could not change to fixtures directory")
+
+				session = Runi18n("-c", "checkup", "-v")
+			})
+
+			It("returns 0", func() {
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			It("prints a reassuring message", func() {
+				Ω(session).Should(Say("OK"))
+			})
 		})
+
+		Context("When there are problems", func() {
+			BeforeEach(func() {
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "checkup", "notsogood")
+				err = os.Chdir(fixturesPath)
+				Ω(err).ToNot(HaveOccurred(), "Could not change to fixtures directory")
+
+				session = Runi18n("-c", "checkup", "-v")
+			})
+
+			It("shows all inconsistent strings and returns 1", func() {
+				output := string(session.Out.Contents())
+
+				// strings wrapped in T() in the code that don't have corresponding keys in the translation files
+				Ω(output).Should(ContainSubstring("\"Heal the world\" exists in the code, but not in en_US"))
+
+				// keys in the translations that don't have corresponding strings wrapped in T() in the code
+				Ω(output).Should(ContainSubstring("\"Make it a better place\" exists in en_US, but not in the code"))
+
+				// keys in non-english translations that don't exist in the english translation
+				Ω(output).Should(ContainSubstring("\"For you and for me\" exists in zh_CN, but not in en_US"))
+
+				// keys that exist in the english translation but are missing in non-english translations
+				Ω(output).Should(ContainSubstring("\"And the entire human race\" exists in en_US, but not in zh_CN"))
+
+				Ω(session.ExitCode()).Should(Equal(1))
+			})
+		})
+
+		Context("When translation IDs are (re)assigned to variables", func() {
+			BeforeEach(func() {
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "checkup", "variable")
+				err = os.Chdir(fixturesPath)
+				Ω(err).ToNot(HaveOccurred(), "Could not change to fixtures directory")
+
+				session = Runi18n("-c", "checkup", "-v")
+			})
+
+			It("returns 0", func() {
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			It("prints a reassuring message", func() {
+				Ω(session).Should(Say("OK"))
+			})
+		})
+
 	})
 
-	Context("when the i18n package is fully qualified", func() {
-		BeforeEach(func() {
-			fixturesPath = filepath.Join("..", "..", "test_fixtures", "checkup", "qualified")
-			err = os.Chdir(fixturesPath)
-			Ω(err).ToNot(HaveOccurred(), "Could not change to fixtures directory")
+	Context("Using cobra commands", func() {
 
-			session = Runi18n("-c", "checkup", "-v", "-q", "i18n")
+		Context("When there are no problems", func() {
+			BeforeEach(func() {
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "checkup", "allgood")
+				err = os.Chdir(fixturesPath)
+				Ω(err).ToNot(HaveOccurred(), "Could not change to fixtures directory")
+
+				session = Runi18n("checkup", "-v")
+			})
+
+			It("returns 0", func() {
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			It("prints a reassuring message", func() {
+				Ω(session).Should(Say("OK"))
+			})
 		})
 
-		It("returns 0", func() {
-			Ω(session.ExitCode()).Should(Equal(0))
+		Context("when the i18n package is fully qualified", func() {
+			BeforeEach(func() {
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "checkup", "qualified")
+				err = os.Chdir(fixturesPath)
+				Ω(err).ToNot(HaveOccurred(), "Could not change to fixtures directory")
+
+				session = Runi18n("-c", "checkup", "-v", "-q", "i18n")
+			})
+
+			It("returns 0", func() {
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			It("prints a reassuring message", func() {
+				session = Runi18n("-c", "checkup", "-v", "-q", "i18n")
+				Ω(session).Should(Say("OK"))
+			})
 		})
 
-		It("prints a reassuring message", func() {
-			session = Runi18n("-c", "checkup", "-v", "-q", "i18n")
-			Ω(session).Should(Say("OK"))
-		})
-	})
+		Context("When the translation files is in format all.<lang>.json", func() {
+			BeforeEach(func() {
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "checkup", "fileformat")
+				err = os.Chdir(fixturesPath)
+				Ω(err).ToNot(HaveOccurred(), "Could not change to fixtures directory")
 
-	Context("When the translation files is in format all.<lang>.json", func() {
-		BeforeEach(func() {
-			fixturesPath = filepath.Join("..", "..", "test_fixtures", "checkup", "fileformat")
-			err = os.Chdir(fixturesPath)
-			Ω(err).ToNot(HaveOccurred(), "Could not change to fixtures directory")
+				session = Runi18n("-c", "checkup", "-v")
+			})
 
-			session = Runi18n("-c", "checkup", "-v")
-		})
+			It("returns 0", func() {
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
 
-		It("returns 0", func() {
-			Ω(session.ExitCode()).Should(Equal(0))
-		})
-
-		It("prints a reassuring message", func() {
-			Ω(session).Should(Say("OK"))
-		})
-	})
-
-	Context("When there are problems", func() {
-		BeforeEach(func() {
-			fixturesPath = filepath.Join("..", "..", "test_fixtures", "checkup", "notsogood")
-			err = os.Chdir(fixturesPath)
-			Ω(err).ToNot(HaveOccurred(), "Could not change to fixtures directory")
-
-			session = Runi18n("-c", "checkup", "-v")
+			It("prints a reassuring message", func() {
+				Ω(session).Should(Say("OK"))
+			})
 		})
 
-		It("shows all inconsistent strings and returns 1", func() {
-			output := string(session.Out.Contents())
+		Context("When there are problems", func() {
+			BeforeEach(func() {
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "checkup", "notsogood")
+				err = os.Chdir(fixturesPath)
+				Ω(err).ToNot(HaveOccurred(), "Could not change to fixtures directory")
 
-			// strings wrapped in T() in the code that don't have corresponding keys in the translation files
-			Ω(output).Should(ContainSubstring("\"Heal the world\" exists in the code, but not in en_US"))
+				session = Runi18n("-c", "checkup", "-v")
+			})
 
-			// keys in the translations that don't have corresponding strings wrapped in T() in the code
-			Ω(output).Should(ContainSubstring("\"Make it a better place\" exists in en_US, but not in the code"))
+			It("shows all inconsistent strings and returns 1", func() {
+				output := string(session.Out.Contents())
 
-			// keys in non-english translations that don't exist in the english translation
-			Ω(output).Should(ContainSubstring("\"For you and for me\" exists in zh_CN, but not in en_US"))
+				// strings wrapped in T() in the code that don't have corresponding keys in the translation files
+				Ω(output).Should(ContainSubstring("\"Heal the world\" exists in the code, but not in en_US"))
 
-			// keys that exist in the english translation but are missing in non-english translations
-			Ω(output).Should(ContainSubstring("\"And the entire human race\" exists in en_US, but not in zh_CN"))
+				// keys in the translations that don't have corresponding strings wrapped in T() in the code
+				Ω(output).Should(ContainSubstring("\"Make it a better place\" exists in en_US, but not in the code"))
 
-			Ω(session.ExitCode()).Should(Equal(1))
-		})
-	})
+				// keys in non-english translations that don't exist in the english translation
+				Ω(output).Should(ContainSubstring("\"For you and for me\" exists in zh_CN, but not in en_US"))
 
-	Context("When translation IDs are (re)assigned to variables", func() {
-		BeforeEach(func() {
-			fixturesPath = filepath.Join("..", "..", "test_fixtures", "checkup", "variable")
-			err = os.Chdir(fixturesPath)
-			Ω(err).ToNot(HaveOccurred(), "Could not change to fixtures directory")
+				// keys that exist in the english translation but are missing in non-english translations
+				Ω(output).Should(ContainSubstring("\"And the entire human race\" exists in en_US, but not in zh_CN"))
 
-			session = Runi18n("-c", "checkup", "-v")
-		})
-
-		It("returns 0", func() {
-			Ω(session.ExitCode()).Should(Equal(0))
+				Ω(session.ExitCode()).Should(Equal(1))
+			})
 		})
 
-		It("prints a reassuring message", func() {
-			Ω(session).Should(Say("OK"))
+		Context("When translation IDs are (re)assigned to variables", func() {
+			BeforeEach(func() {
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "checkup", "variable")
+				err = os.Chdir(fixturesPath)
+				Ω(err).ToNot(HaveOccurred(), "Could not change to fixtures directory")
+
+				session = Runi18n("-c", "checkup", "-v")
+			})
+
+			It("returns 0", func() {
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			It("prints a reassuring message", func() {
+				Ω(session).Should(Say("OK"))
+			})
 		})
+
 	})
 })

--- a/integration/create_translations/f_option_test.go
+++ b/integration/create_translations/f_option_test.go
@@ -40,75 +40,153 @@ var _ = Describe("create-translations -f fileName --languages \"[lang,?]+\"", fu
 		expectedFilesPath = filepath.Join(fixturesPath, "expected_output")
 	})
 
-	Context("when valid input file is provided", func() {
-		Context("and a single language is specified", func() {
-			BeforeEach(func() {
-				session := Runi18n("-c", "create-translations", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"fr\"", "-o", expectedFilesPath)
-				Ω(session.ExitCode()).Should(Equal(0))
+	Context("Using legacy commands", func() {
+		Context("when valid input file is provided", func() {
+			Context("and a single language is specified", func() {
+				BeforeEach(func() {
+					session := Runi18n("-c", "create-translations", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"fr\"", "-o", expectedFilesPath)
+					Ω(session.ExitCode()).Should(Equal(0))
+				})
+
+				AfterEach(func() {
+					RemoveAllFiles(
+						GetFilePath(expectedFilesPath, "quota.go.fr.json"),
+					)
+				})
+
+				It("creates the language file", func() {
+					fileInfo, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.fr.json"))
+					Ω(err).Should(BeNil())
+					Ω(fileInfo.Name()).Should(Equal("quota.go.fr.json"))
+				})
 			})
 
-			AfterEach(func() {
-				RemoveAllFiles(
-					GetFilePath(expectedFilesPath, "quota.go.fr.json"),
-				)
+			Context("and multiple languages are specified", func() {
+				BeforeEach(func() {
+					session := Runi18n("-c", "create-translations", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"fr,de\"", "-o", expectedFilesPath)
+					Ω(session.ExitCode()).Should(Equal(0))
+				})
+
+				AfterEach(func() {
+					RemoveAllFiles(
+						GetFilePath(expectedFilesPath, "quota.go.fr.json"),
+						GetFilePath(expectedFilesPath, "quota.go.de.json"),
+					)
+				})
+
+				It("creates a language file for each language specified", func() {
+					fileInfo, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.fr.json"))
+					Ω(err).Should(BeNil())
+					Ω(fileInfo.Name()).Should(Equal("quota.go.fr.json"))
+
+					fileInfo, err = os.Stat(GetFilePath(expectedFilesPath, "quota.go.de.json"))
+					Ω(err).Should(BeNil())
+					Ω(fileInfo.Name()).Should(Equal("quota.go.de.json"))
+				})
 			})
 
-			It("creates the language file", func() {
-				fileInfo, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.fr.json"))
-				Ω(err).Should(BeNil())
-				Ω(fileInfo.Name()).Should(Equal("quota.go.fr.json"))
-			})
 		})
 
-		Context("and multiple languages are specified", func() {
-			BeforeEach(func() {
-				session := Runi18n("-c", "create-translations", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"fr,de\"", "-o", expectedFilesPath)
-				Ω(session.ExitCode()).Should(Equal(0))
+		Context("when invalid input file is provided", func() {
+			Context("and file does not exist", func() {
+				BeforeEach(func() {
+					session := Runi18n("-c", "create-translations", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.de.json"), "--languages", "\"fr\"", "-o", expectedFilesPath, "--source-language", "zh_TW")
+					Ω(session.ExitCode()).Should(Equal(1))
+				})
+
+				It("fails verification", func() {
+					_, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.fr.json"))
+					Ω(os.IsNotExist(err)).Should(Equal(true))
+				})
 			})
 
-			AfterEach(func() {
-				RemoveAllFiles(
-					GetFilePath(expectedFilesPath, "quota.go.fr.json"),
-					GetFilePath(expectedFilesPath, "quota.go.de.json"),
-				)
-			})
+			Context("and file is empty", func() {
+				BeforeEach(func() {
+					session := Runi18n("-c", "create-translations", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.ja.json"), "--languages", "\"fr\"", "-o", expectedFilesPath, "--source-language", "ja")
+					Ω(session.ExitCode()).Should(Equal(1))
+				})
 
-			It("creates a language file for each language specified", func() {
-				fileInfo, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.fr.json"))
-				Ω(err).Should(BeNil())
-				Ω(fileInfo.Name()).Should(Equal("quota.go.fr.json"))
-
-				fileInfo, err = os.Stat(GetFilePath(expectedFilesPath, "quota.go.de.json"))
-				Ω(err).Should(BeNil())
-				Ω(fileInfo.Name()).Should(Equal("quota.go.de.json"))
+				It("fails verification", func() {
+					_, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.ja.json"))
+					Ω(os.IsNotExist(err)).Should(Equal(true))
+				})
 			})
 		})
 
 	})
 
-	Context("when invalid input file is provided", func() {
-		Context("and file does not exist", func() {
-			BeforeEach(func() {
-				session := Runi18n("-c", "create-translations", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.de.json"), "--languages", "\"fr\"", "-o", expectedFilesPath, "--source-language", "zh_TW")
-				Ω(session.ExitCode()).Should(Equal(1))
+	Context("Using cobra commands", func() {
+		Context("when valid input file is provided", func() {
+			Context("and a single language is specified", func() {
+				BeforeEach(func() {
+					session := Runi18n("create-translations", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"fr\"", "-o", expectedFilesPath)
+					Ω(session.ExitCode()).Should(Equal(0))
+				})
+
+				AfterEach(func() {
+					RemoveAllFiles(
+						GetFilePath(expectedFilesPath, "quota.go.fr.json"),
+					)
+				})
+
+				It("creates the language file", func() {
+					fileInfo, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.fr.json"))
+					Ω(err).Should(BeNil())
+					Ω(fileInfo.Name()).Should(Equal("quota.go.fr.json"))
+				})
 			})
 
-			It("fails verification", func() {
-				_, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.fr.json"))
-				Ω(os.IsNotExist(err)).Should(Equal(true))
+			Context("and multiple languages are specified", func() {
+				BeforeEach(func() {
+					session := Runi18n("create-translations", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"fr,de\"", "-o", expectedFilesPath)
+					Ω(session.ExitCode()).Should(Equal(0))
+				})
+
+				AfterEach(func() {
+					RemoveAllFiles(
+						GetFilePath(expectedFilesPath, "quota.go.fr.json"),
+						GetFilePath(expectedFilesPath, "quota.go.de.json"),
+					)
+				})
+
+				It("creates a language file for each language specified", func() {
+					fileInfo, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.fr.json"))
+					Ω(err).Should(BeNil())
+					Ω(fileInfo.Name()).Should(Equal("quota.go.fr.json"))
+
+					fileInfo, err = os.Stat(GetFilePath(expectedFilesPath, "quota.go.de.json"))
+					Ω(err).Should(BeNil())
+					Ω(fileInfo.Name()).Should(Equal("quota.go.de.json"))
+				})
+			})
+
+		})
+
+		Context("when invalid input file is provided", func() {
+			Context("and file does not exist", func() {
+				BeforeEach(func() {
+					session := Runi18n("create-translations", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.de.json"), "--languages", "\"fr\"", "-o", expectedFilesPath, "--source-language", "zh_TW")
+					Ω(session.ExitCode()).Should(Equal(1))
+				})
+
+				It("fails verification", func() {
+					_, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.fr.json"))
+					Ω(os.IsNotExist(err)).Should(Equal(true))
+				})
+			})
+
+			Context("and file is empty", func() {
+				BeforeEach(func() {
+					session := Runi18n("create-translations", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.ja.json"), "--languages", "\"fr\"", "-o", expectedFilesPath, "--source-language", "ja")
+					Ω(session.ExitCode()).Should(Equal(1))
+				})
+
+				It("fails verification", func() {
+					_, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.ja.json"))
+					Ω(os.IsNotExist(err)).Should(Equal(true))
+				})
 			})
 		})
 
-		Context("and file is empty", func() {
-			BeforeEach(func() {
-				session := Runi18n("-c", "create-translations", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.ja.json"), "--languages", "\"fr\"", "-o", expectedFilesPath, "--source-language", "ja")
-				Ω(session.ExitCode()).Should(Equal(1))
-			})
-
-			It("fails verification", func() {
-				_, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.ja.json"))
-				Ω(os.IsNotExist(err)).Should(Equal(true))
-			})
-		})
 	})
 })

--- a/integration/extract_strings/d_option_test.go
+++ b/integration/extract_strings/d_option_test.go
@@ -49,60 +49,123 @@ var _ = Describe("extract-strings -d dirName", func() {
 		os.RemoveAll(outputPath)
 	})
 
-	Context("When i18n4go4go is run with the -d flag", func() {
-		BeforeEach(func() {
-			session := Runi18n("-c", "extract-strings", "-v", "--po", "--meta", "-d", inputFilesPath, "-o", outputPath, "--ignore-regexp", "^[.]\\w+.go$")
+	Context("Using legacy commands", func() {
+		Context("When i18n4go4go is run with the -d flag", func() {
+			BeforeEach(func() {
+				session := Runi18n("-c", "extract-strings", "-v", "--po", "--meta", "-d", inputFilesPath, "-o", outputPath, "--ignore-regexp", "^[.]\\w+.go$")
 
-			Ω(session.ExitCode()).Should(Equal(0))
-		})
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
 
-		It("Walks input directory and compares each group of generated output to expected output", func() {
-			filepath.Walk(inputFilesPath, func(path string, info os.FileInfo, err error) error {
-				if info.IsDir() {
+			It("Walks input directory and compares each group of generated output to expected output", func() {
+				filepath.Walk(inputFilesPath, func(path string, info os.FileInfo, err error) error {
+					if info.IsDir() {
+						return nil
+					}
+
+					CompareExpectedToGeneratedTraslationJson(
+						filepath.Join(expectedFilesPath, strings.Join([]string{filepath.Base(path), "en.json"}, ".")),
+						filepath.Join(outputPath, strings.Join([]string{filepath.Base(path), "en.json"}, ".")),
+					)
+
+					CompareExpectedToGeneratedPo(
+						filepath.Join(expectedFilesPath, strings.Join([]string{filepath.Base(path), "en.po"}, ".")),
+						filepath.Join(outputPath, strings.Join([]string{filepath.Base(path), "en.po"}, ".")),
+					)
+
 					return nil
-				}
-
-				CompareExpectedToGeneratedTraslationJson(
-					filepath.Join(expectedFilesPath, strings.Join([]string{filepath.Base(path), "en.json"}, ".")),
-					filepath.Join(outputPath, strings.Join([]string{filepath.Base(path), "en.json"}, ".")),
-				)
-
-				CompareExpectedToGeneratedPo(
-					filepath.Join(expectedFilesPath, strings.Join([]string{filepath.Base(path), "en.po"}, ".")),
-					filepath.Join(outputPath, strings.Join([]string{filepath.Base(path), "en.po"}, ".")),
-				)
-
-				return nil
+				})
 			})
 		})
+
+		Context("When i18n4go4go is run with the -d -r flags", func() {
+			BeforeEach(func() {
+				inputFilesPath = filepath.Join(inputFilesPath, "..")
+
+				session := Runi18n("-c", "extract-strings", "-v", "--po", "--meta", "-d", inputFilesPath, "-o", outputPath, "-r", "--ignore-regexp", "^[.]\\w+.go$")
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			It("Walks input directories and compares each group of generated output to expected output", func() {
+				filepath.Walk(inputFilesPath, func(path string, info os.FileInfo, err error) error {
+					if info.IsDir() {
+						return nil
+					}
+
+					CompareExpectedToGeneratedTraslationJson(
+						filepath.Join(expectedFilesPath, strings.Join([]string{filepath.Base(path), "en.json"}, ".")),
+						filepath.Join(outputPath, strings.Join([]string{filepath.Base(path), "en.json"}, ".")),
+					)
+
+					CompareExpectedToGeneratedPo(
+						filepath.Join(expectedFilesPath, strings.Join([]string{filepath.Base(path), "en.po"}, ".")),
+						filepath.Join(outputPath, strings.Join([]string{filepath.Base(path), "en.po"}, ".")),
+					)
+
+					return nil
+				})
+			})
+		})
+
 	})
 
-	Context("When i18n4go4go is run with the -d -r flags", func() {
-		BeforeEach(func() {
-			inputFilesPath = filepath.Join(inputFilesPath, "..")
+	Context("Using cobra commands", func() {
+		Context("When i18n4go4go is run with the -d flag", func() {
+			BeforeEach(func() {
+				session := Runi18n("extract-strings", "-v", "--po", "--meta", "-d", inputFilesPath, "-o", outputPath, "--ignore-regexp", "^[.]\\w+.go$")
 
-			session := Runi18n("-c", "extract-strings", "-v", "--po", "--meta", "-d", inputFilesPath, "-o", outputPath, "-r", "--ignore-regexp", "^[.]\\w+.go$")
-			Ω(session.ExitCode()).Should(Equal(0))
-		})
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
 
-		It("Walks input directories and compares each group of generated output to expected output", func() {
-			filepath.Walk(inputFilesPath, func(path string, info os.FileInfo, err error) error {
-				if info.IsDir() {
+			It("Walks input directory and compares each group of generated output to expected output", func() {
+				filepath.Walk(inputFilesPath, func(path string, info os.FileInfo, err error) error {
+					if info.IsDir() {
+						return nil
+					}
+
+					CompareExpectedToGeneratedTraslationJson(
+						filepath.Join(expectedFilesPath, strings.Join([]string{filepath.Base(path), "en.json"}, ".")),
+						filepath.Join(outputPath, strings.Join([]string{filepath.Base(path), "en.json"}, ".")),
+					)
+
+					CompareExpectedToGeneratedPo(
+						filepath.Join(expectedFilesPath, strings.Join([]string{filepath.Base(path), "en.po"}, ".")),
+						filepath.Join(outputPath, strings.Join([]string{filepath.Base(path), "en.po"}, ".")),
+					)
+
 					return nil
-				}
-
-				CompareExpectedToGeneratedTraslationJson(
-					filepath.Join(expectedFilesPath, strings.Join([]string{filepath.Base(path), "en.json"}, ".")),
-					filepath.Join(outputPath, strings.Join([]string{filepath.Base(path), "en.json"}, ".")),
-				)
-
-				CompareExpectedToGeneratedPo(
-					filepath.Join(expectedFilesPath, strings.Join([]string{filepath.Base(path), "en.po"}, ".")),
-					filepath.Join(outputPath, strings.Join([]string{filepath.Base(path), "en.po"}, ".")),
-				)
-
-				return nil
+				})
 			})
 		})
+
+		Context("When i18n4go4go is run with the -d -r flags", func() {
+			BeforeEach(func() {
+				inputFilesPath = filepath.Join(inputFilesPath, "..")
+
+				session := Runi18n("extract-strings", "-v", "--po", "--meta", "-d", inputFilesPath, "-o", outputPath, "-r", "--ignore-regexp", "^[.]\\w+.go$")
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			It("Walks input directories and compares each group of generated output to expected output", func() {
+				filepath.Walk(inputFilesPath, func(path string, info os.FileInfo, err error) error {
+					if info.IsDir() {
+						return nil
+					}
+
+					CompareExpectedToGeneratedTraslationJson(
+						filepath.Join(expectedFilesPath, strings.Join([]string{filepath.Base(path), "en.json"}, ".")),
+						filepath.Join(outputPath, strings.Join([]string{filepath.Base(path), "en.json"}, ".")),
+					)
+
+					CompareExpectedToGeneratedPo(
+						filepath.Join(expectedFilesPath, strings.Join([]string{filepath.Base(path), "en.po"}, ".")),
+						filepath.Join(outputPath, strings.Join([]string{filepath.Base(path), "en.po"}, ".")),
+					)
+
+					return nil
+				})
+			})
+		})
+
 	})
 })

--- a/integration/extract_strings/f_o_options_test.go
+++ b/integration/extract_strings/f_o_options_test.go
@@ -50,55 +50,111 @@ var _ = Describe("extract-strings -f fileName -o outputDir", func() {
 	AfterEach(func() {
 		os.RemoveAll(outputPath)
 	})
+	Context("Using legacy commands", func() {
+		Context("-o outputDir --output-flat (default)", func() {
+			BeforeEach(func() {
+				session := Runi18n("-c", "extract-strings", "-v", "--po", "--meta", "-f", filepath.Join(inputFilesPath, "app.go"), "-o", outputPath)
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
 
-	Context("-o outputDir --output-flat (default)", func() {
-		BeforeEach(func() {
-			session := Runi18n("-c", "extract-strings", "-v", "--po", "--meta", "-f", filepath.Join(inputFilesPath, "app.go"), "-o", outputPath)
-			Ω(session.ExitCode()).Should(Equal(0))
+			It("Walks input directory and compares each group of generated output to expected output", func() {
+
+				CompareExpectedToGeneratedTraslationJson(
+					filepath.Join(expectedFilesPath, "app.go.en.json"),
+					filepath.Join(outputPath, "app.go.en.json"),
+				)
+
+				CompareExpectedToGeneratedExtendedJson(
+					filepath.Join(expectedFilesPath, "app.go.extracted.json"),
+					filepath.Join(outputPath, "app.go.extracted.json"),
+				)
+
+				CompareExpectedToGeneratedPo(
+					filepath.Join(expectedFilesPath, "app.go.en.po"),
+					filepath.Join(outputPath, "app.go.en.po"),
+				)
+			})
 		})
 
-		It("Walks input directory and compares each group of generated output to expected output", func() {
+		Context("-o outputDir --output-match-package", func() {
+			BeforeEach(func() {
+				session := Runi18n("-c", "extract-strings", "-v", "--po", "--meta", "-f", filepath.Join(inputFilesPath, "app.go"), "-o", outputPath, "--output-match-package")
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
 
-			CompareExpectedToGeneratedTraslationJson(
-				filepath.Join(expectedFilesPath, "app.go.en.json"),
-				filepath.Join(outputPath, "app.go.en.json"),
-			)
+			It("Walks input directory and compares each group of generated output to expected output and package subdirectories", func() {
+				expectedFilesPath = filepath.Join(expectedFilesPath, "app")
+				outputPath = filepath.Join(outputPath, "app")
+				CompareExpectedToGeneratedTraslationJson(
+					filepath.Join(expectedFilesPath, "app.go.en.json"),
+					filepath.Join(outputPath, "app.go.en.json"),
+				)
 
-			CompareExpectedToGeneratedExtendedJson(
-				filepath.Join(expectedFilesPath, "app.go.extracted.json"),
-				filepath.Join(outputPath, "app.go.extracted.json"),
-			)
+				CompareExpectedToGeneratedExtendedJson(
+					filepath.Join(expectedFilesPath, "app.go.extracted.json"),
+					filepath.Join(outputPath, "app.go.extracted.json"),
+				)
 
-			CompareExpectedToGeneratedPo(
-				filepath.Join(expectedFilesPath, "app.go.en.po"),
-				filepath.Join(outputPath, "app.go.en.po"),
-			)
+				CompareExpectedToGeneratedPo(
+					filepath.Join(expectedFilesPath, "app.go.en.po"),
+					filepath.Join(outputPath, "app.go.en.po"),
+				)
+			})
 		})
+
 	})
 
-	Context("-o outputDir --output-match-package", func() {
-		BeforeEach(func() {
-			session := Runi18n("-c", "extract-strings", "-v", "--po", "--meta", "-f", filepath.Join(inputFilesPath, "app.go"), "-o", outputPath, "--output-match-package")
-			Ω(session.ExitCode()).Should(Equal(0))
+	Context("Using cobra commands", func() {
+		Context("-o outputDir --output-flat (default)", func() {
+			BeforeEach(func() {
+				session := Runi18n("extract-strings", "-v", "--po", "--meta", "-f", filepath.Join(inputFilesPath, "app.go"), "-o", outputPath)
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			It("Walks input directory and compares each group of generated output to expected output", func() {
+
+				CompareExpectedToGeneratedTraslationJson(
+					filepath.Join(expectedFilesPath, "app.go.en.json"),
+					filepath.Join(outputPath, "app.go.en.json"),
+				)
+
+				CompareExpectedToGeneratedExtendedJson(
+					filepath.Join(expectedFilesPath, "app.go.extracted.json"),
+					filepath.Join(outputPath, "app.go.extracted.json"),
+				)
+
+				CompareExpectedToGeneratedPo(
+					filepath.Join(expectedFilesPath, "app.go.en.po"),
+					filepath.Join(outputPath, "app.go.en.po"),
+				)
+			})
 		})
 
-		It("Walks input directory and compares each group of generated output to expected output and package subdirectories", func() {
-			expectedFilesPath = filepath.Join(expectedFilesPath, "app")
-			outputPath = filepath.Join(outputPath, "app")
-			CompareExpectedToGeneratedTraslationJson(
-				filepath.Join(expectedFilesPath, "app.go.en.json"),
-				filepath.Join(outputPath, "app.go.en.json"),
-			)
+		Context("-o outputDir --output-match-package", func() {
+			BeforeEach(func() {
+				session := Runi18n("extract-strings", "-v", "--po", "--meta", "-f", filepath.Join(inputFilesPath, "app.go"), "-o", outputPath, "--output-match-package")
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
 
-			CompareExpectedToGeneratedExtendedJson(
-				filepath.Join(expectedFilesPath, "app.go.extracted.json"),
-				filepath.Join(outputPath, "app.go.extracted.json"),
-			)
+			It("Walks input directory and compares each group of generated output to expected output and package subdirectories", func() {
+				expectedFilesPath = filepath.Join(expectedFilesPath, "app")
+				outputPath = filepath.Join(outputPath, "app")
+				CompareExpectedToGeneratedTraslationJson(
+					filepath.Join(expectedFilesPath, "app.go.en.json"),
+					filepath.Join(outputPath, "app.go.en.json"),
+				)
 
-			CompareExpectedToGeneratedPo(
-				filepath.Join(expectedFilesPath, "app.go.en.po"),
-				filepath.Join(outputPath, "app.go.en.po"),
-			)
+				CompareExpectedToGeneratedExtendedJson(
+					filepath.Join(expectedFilesPath, "app.go.extracted.json"),
+					filepath.Join(outputPath, "app.go.extracted.json"),
+				)
+
+				CompareExpectedToGeneratedPo(
+					filepath.Join(expectedFilesPath, "app.go.en.po"),
+					filepath.Join(outputPath, "app.go.en.po"),
+				)
+			})
 		})
+
 	})
 })

--- a/integration/extract_strings/f_option_test.go
+++ b/integration/extract_strings/f_option_test.go
@@ -40,123 +40,247 @@ var _ = Describe("extract-strings -f fileName", func() {
 		expectedFilesPath = filepath.Join(fixturesPath, "expected_output")
 	})
 
-	Context("compare generated and expected file", func() {
-		BeforeEach(func() {
-			session := Runi18n("-c", "extract-strings", "-v", "--po", "--meta", "-f", filepath.Join(inputFilesPath, "app.go"))
-			Ω(session.ExitCode()).Should(Equal(0))
+	Context("Using legacy commands", func() {
+		Context("compare generated and expected file", func() {
+			BeforeEach(func() {
+				session := Runi18n("-c", "extract-strings", "-v", "--po", "--meta", "-f", filepath.Join(inputFilesPath, "app.go"))
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			AfterEach(func() {
+				RemoveAllFiles(
+					GetFilePath(inputFilesPath, "app.go.en.json"),
+					GetFilePath(inputFilesPath, "app.go.en.po"),
+					GetFilePath(inputFilesPath, "app.go.extracted.json"),
+				)
+			})
+
+			It("app.go.en.json", func() {
+				CompareExpectedToGeneratedTraslationJson(
+					GetFilePath(expectedFilesPath, "app.go.en.json"),
+					GetFilePath(inputFilesPath, "app.go.en.json"),
+				)
+			})
+
+			It("app.go.extracted.json", func() {
+				CompareExpectedToGeneratedExtendedJson(
+					GetFilePath(expectedFilesPath, "app.go.extracted.json"),
+					GetFilePath(inputFilesPath, "app.go.extracted.json"),
+				)
+			})
+
+			It("app.go.en.po", func() {
+				CompareExpectedToGeneratedPo(
+					GetFilePath(expectedFilesPath, "app.go.en.po"),
+					GetFilePath(inputFilesPath, "app.go.en.po"),
+				)
+			})
 		})
 
-		AfterEach(func() {
-			RemoveAllFiles(
-				GetFilePath(inputFilesPath, "app.go.en.json"),
-				GetFilePath(inputFilesPath, "app.go.en.po"),
-				GetFilePath(inputFilesPath, "app.go.extracted.json"),
-			)
+		Context("GitHub issue #4: extracting some character as ascii code, e.g., > as \u003e", func() {
+			BeforeEach(func() {
+				session := Runi18n("-c", "extract-strings", "-v", "-f", filepath.Join(inputFilesPath, "issue4.go"))
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			AfterEach(func() {
+				RemoveAllFiles(
+					GetFilePath(inputFilesPath, "issue4.go.en.json"),
+				)
+			})
+
+			It("issue4.go.en.json", func() {
+				CompareExpectedToGeneratedTraslationJson(
+					GetFilePath(expectedFilesPath, "issue4.go.en.json"),
+					GetFilePath(inputFilesPath, "issue4.go.en.json"),
+				)
+			})
 		})
 
-		It("app.go.en.json", func() {
-			CompareExpectedToGeneratedTraslationJson(
-				GetFilePath(expectedFilesPath, "app.go.en.json"),
-				GetFilePath(inputFilesPath, "app.go.en.json"),
-			)
+		Context("GitHub issue #16: Extract Strings should ignore string keys in maps", func() {
+			BeforeEach(func() {
+				session := Runi18n("-c", "extract-strings", "-v", "-f", filepath.Join(inputFilesPath, "issue16.go"))
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			AfterEach(func() {
+				RemoveAllFiles(
+					GetFilePath(inputFilesPath, "issue16.go.en.json"),
+				)
+			})
+
+			It("issue16.go.en.json", func() {
+				CompareExpectedToGeneratedTraslationJson(
+					GetFilePath(expectedFilesPath, "issue16.go.en.json"),
+					GetFilePath(inputFilesPath, "issue16.go.en.json"),
+				)
+			})
 		})
 
-		It("app.go.extracted.json", func() {
-			CompareExpectedToGeneratedExtendedJson(
-				GetFilePath(expectedFilesPath, "app.go.extracted.json"),
-				GetFilePath(inputFilesPath, "app.go.extracted.json"),
+		Context("when the file specified has no strings at all", func() {
+			var (
+				OUTPUT_PATH string
 			)
+
+			BeforeEach(func() {
+				var err error
+				OUTPUT_PATH, err = ioutil.TempDir("", "i18n4go4go")
+				Ω(err).ShouldNot(HaveOccurred())
+
+				session := Runi18n("-c", "extract-strings", "-f", filepath.Join(inputFilesPath, "no_strings.go"), "-o", OUTPUT_PATH)
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			It("does not generate any files", func() {
+				println(OUTPUT_PATH)
+				files, err := ioutil.ReadDir(OUTPUT_PATH)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				Ω(files).Should(BeEmpty())
+			})
 		})
 
-		It("app.go.en.po", func() {
-			CompareExpectedToGeneratedPo(
-				GetFilePath(expectedFilesPath, "app.go.en.po"),
-				GetFilePath(inputFilesPath, "app.go.en.po"),
-			)
+		Context("GitHub issue #45: Extract Strings should extract strings string embedded inside a func, inside a func in a return", func() {
+			BeforeEach(func() {
+				session := Runi18n("-c", "extract-strings", "-v", "-f", filepath.Join(inputFilesPath, "issue45.go"))
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			AfterEach(func() {
+				RemoveAllFiles(
+					GetFilePath(inputFilesPath, "issue45.go.en.json"),
+				)
+			})
+
+			It("generates issue45.go.en.json correctly", func() {
+				CompareExpectedToGeneratedTraslationJson(
+					GetFilePath(expectedFilesPath, "issue45.go.en.json"),
+					GetFilePath(inputFilesPath, "issue45.go.en.json"),
+				)
+			})
 		})
+
 	})
 
-	Context("GitHub issue #4: extracting some character as ascii code, e.g., > as \u003e", func() {
-		BeforeEach(func() {
-			session := Runi18n("-c", "extract-strings", "-v", "-f", filepath.Join(inputFilesPath, "issue4.go"))
-			Ω(session.ExitCode()).Should(Equal(0))
+	Context("Using cobra commands", func() {
+		Context("compare generated and expected file", func() {
+			BeforeEach(func() {
+				session := Runi18n("extract-strings", "-v", "--po", "--meta", "-f", filepath.Join(inputFilesPath, "app.go"))
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			AfterEach(func() {
+				RemoveAllFiles(
+					GetFilePath(inputFilesPath, "app.go.en.json"),
+					GetFilePath(inputFilesPath, "app.go.en.po"),
+					GetFilePath(inputFilesPath, "app.go.extracted.json"),
+				)
+			})
+
+			It("app.go.en.json", func() {
+				CompareExpectedToGeneratedTraslationJson(
+					GetFilePath(expectedFilesPath, "app.go.en.json"),
+					GetFilePath(inputFilesPath, "app.go.en.json"),
+				)
+			})
+
+			It("app.go.extracted.json", func() {
+				CompareExpectedToGeneratedExtendedJson(
+					GetFilePath(expectedFilesPath, "app.go.extracted.json"),
+					GetFilePath(inputFilesPath, "app.go.extracted.json"),
+				)
+			})
+
+			It("app.go.en.po", func() {
+				CompareExpectedToGeneratedPo(
+					GetFilePath(expectedFilesPath, "app.go.en.po"),
+					GetFilePath(inputFilesPath, "app.go.en.po"),
+				)
+			})
 		})
 
-		AfterEach(func() {
-			RemoveAllFiles(
-				GetFilePath(inputFilesPath, "issue4.go.en.json"),
-			)
+		Context("GitHub issue #4: extracting some character as ascii code, e.g., > as \u003e", func() {
+			BeforeEach(func() {
+				session := Runi18n("extract-strings", "-v", "-f", filepath.Join(inputFilesPath, "issue4.go"))
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			AfterEach(func() {
+				RemoveAllFiles(
+					GetFilePath(inputFilesPath, "issue4.go.en.json"),
+				)
+			})
+
+			It("issue4.go.en.json", func() {
+				CompareExpectedToGeneratedTraslationJson(
+					GetFilePath(expectedFilesPath, "issue4.go.en.json"),
+					GetFilePath(inputFilesPath, "issue4.go.en.json"),
+				)
+			})
 		})
 
-		It("issue4.go.en.json", func() {
-			CompareExpectedToGeneratedTraslationJson(
-				GetFilePath(expectedFilesPath, "issue4.go.en.json"),
-				GetFilePath(inputFilesPath, "issue4.go.en.json"),
-			)
+		Context("GitHub issue #16: Extract Strings should ignore string keys in maps", func() {
+			BeforeEach(func() {
+				session := Runi18n("extract-strings", "-v", "-f", filepath.Join(inputFilesPath, "issue16.go"))
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			AfterEach(func() {
+				RemoveAllFiles(
+					GetFilePath(inputFilesPath, "issue16.go.en.json"),
+				)
+			})
+
+			It("issue16.go.en.json", func() {
+				CompareExpectedToGeneratedTraslationJson(
+					GetFilePath(expectedFilesPath, "issue16.go.en.json"),
+					GetFilePath(inputFilesPath, "issue16.go.en.json"),
+				)
+			})
 		})
+
+		Context("when the file specified has no strings at all", func() {
+			var (
+				OUTPUT_PATH string
+			)
+
+			BeforeEach(func() {
+				var err error
+				OUTPUT_PATH, err = ioutil.TempDir("", "i18n4go4go")
+				Ω(err).ShouldNot(HaveOccurred())
+
+				session := Runi18n("extract-strings", "-f", filepath.Join(inputFilesPath, "no_strings.go"), "-o", OUTPUT_PATH)
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			It("does not generate any files", func() {
+				println(OUTPUT_PATH)
+				files, err := ioutil.ReadDir(OUTPUT_PATH)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				Ω(files).Should(BeEmpty())
+			})
+		})
+
+		Context("GitHub issue #45: Extract Strings should extract strings string embedded inside a func, inside a func in a return", func() {
+			BeforeEach(func() {
+				session := Runi18n("extract-strings", "-v", "-f", filepath.Join(inputFilesPath, "issue45.go"))
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			AfterEach(func() {
+				RemoveAllFiles(
+					GetFilePath(inputFilesPath, "issue45.go.en.json"),
+				)
+			})
+
+			It("generates issue45.go.en.json correctly", func() {
+				CompareExpectedToGeneratedTraslationJson(
+					GetFilePath(expectedFilesPath, "issue45.go.en.json"),
+					GetFilePath(inputFilesPath, "issue45.go.en.json"),
+				)
+			})
+		})
+
 	})
-
-	Context("GitHub issue #16: Extract Strings should ignore string keys in maps", func() {
-		BeforeEach(func() {
-			session := Runi18n("-c", "extract-strings", "-v", "-f", filepath.Join(inputFilesPath, "issue16.go"))
-			Ω(session.ExitCode()).Should(Equal(0))
-		})
-
-		AfterEach(func() {
-			RemoveAllFiles(
-				GetFilePath(inputFilesPath, "issue16.go.en.json"),
-			)
-		})
-
-		It("issue16.go.en.json", func() {
-			CompareExpectedToGeneratedTraslationJson(
-				GetFilePath(expectedFilesPath, "issue16.go.en.json"),
-				GetFilePath(inputFilesPath, "issue16.go.en.json"),
-			)
-		})
-	})
-
-	Context("when the file specified has no strings at all", func() {
-		var (
-			OUTPUT_PATH string
-		)
-
-		BeforeEach(func() {
-			var err error
-			OUTPUT_PATH, err = ioutil.TempDir("", "i18n4go4go")
-			Ω(err).ShouldNot(HaveOccurred())
-
-			session := Runi18n("-c", "extract-strings", "-f", filepath.Join(inputFilesPath, "no_strings.go"), "-o", OUTPUT_PATH)
-			Ω(session.ExitCode()).Should(Equal(0))
-		})
-
-		It("does not generate any files", func() {
-			println(OUTPUT_PATH)
-			files, err := ioutil.ReadDir(OUTPUT_PATH)
-			Ω(err).ShouldNot(HaveOccurred())
-
-			Ω(files).Should(BeEmpty())
-		})
-	})
-
-	Context("GitHub issue #45: Extract Strings should extract strings string embedded inside a func, inside a func in a return", func() {
-		BeforeEach(func() {
-			session := Runi18n("-c", "extract-strings", "-v", "-f", filepath.Join(inputFilesPath, "issue45.go"))
-			Ω(session.ExitCode()).Should(Equal(0))
-		})
-
-		AfterEach(func() {
-			RemoveAllFiles(
-				GetFilePath(inputFilesPath, "issue45.go.en.json"),
-			)
-		})
-
-		It("generates issue45.go.en.json correctly", func() {
-			CompareExpectedToGeneratedTraslationJson(
-				GetFilePath(expectedFilesPath, "issue45.go.en.json"),
-				GetFilePath(inputFilesPath, "issue45.go.en.json"),
-			)
-		})
-	})
-
 })

--- a/integration/extract_strings/s_option_test.go
+++ b/integration/extract_strings/s_option_test.go
@@ -52,40 +52,83 @@ var _ = Describe("extract-strings -s filePath", func() {
 		os.RemoveAll(outputPath)
 	})
 
-	Context("When i18n4go4go is run with the -s flag", func() {
-		BeforeEach(func() {
-			session := Runi18n("-c", "extract-strings", "-v", "-f", inputFilesPath, "-o", outputPath, "-s", matchingGroupFilePath)
+	Context("Using legacy commands", func() {
+		Context("When i18n4go4go is run with the -s flag", func() {
+			BeforeEach(func() {
+				session := Runi18n("-c", "extract-strings", "-v", "-f", inputFilesPath, "-o", outputPath, "-s", matchingGroupFilePath)
 
-			Ω(session.ExitCode()).Should(Equal(0))
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			It("use the regexFile to parse substring", func() {
+				expectedFilePath := filepath.Join(expectedFilesPath, "app.go.en.json")
+				actualFilePath := filepath.Join(outputPath, "app.go.en.json")
+
+				expectedBytes, err := ioutil.ReadFile(expectedFilePath)
+				Ω(err).Should(BeNil())
+				Ω(expectedBytes).ShouldNot(BeNil())
+
+				actualBytes, err := ioutil.ReadFile(actualFilePath)
+				Ω(err).Should(BeNil())
+				Ω(actualBytes).ShouldNot(BeNil())
+
+				var translations []common.I18nStringInfo
+				err = json.Unmarshal(actualBytes, &translations)
+				Ω(err).Should(BeNil())
+
+				Ω(translations).To(ContainElement(common.I18nStringInfo{
+					ID:          "a string",
+					Translation: "a string",
+					Modified:    false,
+				}))
+
+				Ω(translations).To(ContainElement(common.I18nStringInfo{
+					ID:          "show the app details",
+					Translation: "show the app details",
+					Modified:    false,
+				}))
+			})
 		})
 
-		It("use the regexFile to parse substring", func() {
-			expectedFilePath := filepath.Join(expectedFilesPath, "app.go.en.json")
-			actualFilePath := filepath.Join(outputPath, "app.go.en.json")
+	})
 
-			expectedBytes, err := ioutil.ReadFile(expectedFilePath)
-			Ω(err).Should(BeNil())
-			Ω(expectedBytes).ShouldNot(BeNil())
+	Context("Using cobra commands", func() {
+		Context("When i18n4go4go is run with the -s flag", func() {
+			BeforeEach(func() {
+				session := Runi18n("extract-strings", "-v", "-f", inputFilesPath, "-o", outputPath, "-s", matchingGroupFilePath)
 
-			actualBytes, err := ioutil.ReadFile(actualFilePath)
-			Ω(err).Should(BeNil())
-			Ω(actualBytes).ShouldNot(BeNil())
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
 
-			var translations []common.I18nStringInfo
-			err = json.Unmarshal(actualBytes, &translations)
-			Ω(err).Should(BeNil())
+			It("use the regexFile to parse substring", func() {
+				expectedFilePath := filepath.Join(expectedFilesPath, "app.go.en.json")
+				actualFilePath := filepath.Join(outputPath, "app.go.en.json")
 
-			Ω(translations).To(ContainElement(common.I18nStringInfo{
-				ID:          "a string",
-				Translation: "a string",
-				Modified:    false,
-			}))
+				expectedBytes, err := ioutil.ReadFile(expectedFilePath)
+				Ω(err).Should(BeNil())
+				Ω(expectedBytes).ShouldNot(BeNil())
 
-			Ω(translations).To(ContainElement(common.I18nStringInfo{
-				ID:          "show the app details",
-				Translation: "show the app details",
-				Modified:    false,
-			}))
+				actualBytes, err := ioutil.ReadFile(actualFilePath)
+				Ω(err).Should(BeNil())
+				Ω(actualBytes).ShouldNot(BeNil())
+
+				var translations []common.I18nStringInfo
+				err = json.Unmarshal(actualBytes, &translations)
+				Ω(err).Should(BeNil())
+
+				Ω(translations).To(ContainElement(common.I18nStringInfo{
+					ID:          "a string",
+					Translation: "a string",
+					Modified:    false,
+				}))
+
+				Ω(translations).To(ContainElement(common.I18nStringInfo{
+					ID:          "show the app details",
+					Translation: "show the app details",
+					Modified:    false,
+				}))
+			})
 		})
+
 	})
 })

--- a/integration/rewrite_package/d_option_test.go
+++ b/integration/rewrite_package/d_option_test.go
@@ -38,209 +38,417 @@ var _ = Describe("rewrite-package -d dirname -r", func() {
 		Ω(err).ShouldNot(HaveOccurred())
 	})
 
-	Context("rewrite all templated and interpolated strings", func() {
-		BeforeEach(func() {
-			dir, err := os.Getwd()
-			Ω(err).ShouldNot(HaveOccurred())
+	Context("Using legacy commands", func() {
+		Context("rewrite all templated and interpolated strings", func() {
+			BeforeEach(func() {
+				dir, err := os.Getwd()
+				Ω(err).ShouldNot(HaveOccurred())
 
-			rootPath = filepath.Join(dir, "..", "..")
+				rootPath = filepath.Join(dir, "..", "..")
 
-			outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
-			Ω(err).ShouldNot(HaveOccurred())
+				outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
+				Ω(err).ShouldNot(HaveOccurred())
 
-			fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
-			inputFilesPath = filepath.Join(fixturesPath, "f_option", "input_files")
-			expectedFilesPath = filepath.Join(fixturesPath, "f_option", "expected_output")
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
+				inputFilesPath = filepath.Join(fixturesPath, "f_option", "input_files")
+				expectedFilesPath = filepath.Join(fixturesPath, "f_option", "expected_output")
 
-			session := Runi18n("-c",
-				"rewrite-package",
-				"-d", inputFilesPath,
-				"-o", outputDir,
-				"--ignore-regexp", "^[.]\\w+.go$", //Ignoring .*.go files, otherwise it defaults to ignoring *test*.go
-				"--root-path", rootPath,
-				"-r",
-				"-v",
-			)
+				session := Runi18n("-c",
+					"rewrite-package",
+					"-d", inputFilesPath,
+					"-o", outputDir,
+					"--ignore-regexp", "^[.]\\w+.go$", //Ignoring .*.go files, otherwise it defaults to ignoring *test*.go
+					"--root-path", rootPath,
+					"-r",
+					"-v",
+				)
 
-			Ω(session.ExitCode()).Should(Equal(0))
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			It("adds T() callExprs wrapping string literals", func() {
+				expectedOutputFile := filepath.Join(expectedFilesPath, "test.go")
+				bytes, err := ioutil.ReadFile(expectedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				expectedOutput := string(bytes)
+
+				generatedOutputFile := filepath.Join(outputDir, "test.go")
+				bytes, err = ioutil.ReadFile(generatedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				actualOutput := string(bytes)
+				Ω(actualOutput).Should(Equal(expectedOutput))
+			})
+
+			It("recurses to files in nested dirs", func() {
+				expectedOutputFile := filepath.Join(expectedFilesPath, "nested_dir", "test.go")
+				bytes, err := ioutil.ReadFile(expectedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				expectedOutput := string(bytes)
+
+				generatedOutputFile := filepath.Join(outputDir, "nested_dir", "test.go")
+				bytes, err = ioutil.ReadFile(generatedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				actualOutput := string(bytes)
+				Ω(actualOutput).Should(Equal(expectedOutput))
+			})
+
+			It("adds a i18n_init.go per package", func() {
+				initFile := filepath.Join(outputDir, "i18n_init.go")
+				expectedBytes, err := ioutil.ReadFile(initFile)
+				Ω(err).ShouldNot(HaveOccurred())
+				expected := strings.TrimSpace(string(expectedBytes))
+
+				expectedInitFile := filepath.Join(expectedFilesPath, "i18n_init.go")
+				actualBytes, err := ioutil.ReadFile(expectedInitFile)
+				Ω(err).ShouldNot(HaveOccurred())
+				actual := strings.TrimSpace(string(actualBytes))
+
+				Ω(actual).Should(Equal(expected))
+
+				initFile = filepath.Join(outputDir, "nested_dir", "i18n_init.go")
+				expectedBytes, err = ioutil.ReadFile(initFile)
+				Ω(err).ShouldNot(HaveOccurred())
+				expected = strings.TrimSpace(string(expectedBytes))
+
+				expectedInitFile = filepath.Join(expectedFilesPath, "nested_dir", "i18n_init.go")
+				actualBytes, err = ioutil.ReadFile(expectedInitFile)
+				Ω(err).ShouldNot(HaveOccurred())
+				actual = strings.TrimSpace(string(actualBytes))
+
+				Ω(actual).Should(Equal(expected))
+			})
+
+			It("does not translate test files", func() {
+				_, doesFileExistErr := os.Stat(filepath.Join(outputDir, "a_really_bad_test.go"))
+				Ω(os.IsNotExist(doesFileExistErr)).Should(BeTrue())
+			})
 		})
 
-		It("adds T() callExprs wrapping string literals", func() {
-			expectedOutputFile := filepath.Join(expectedFilesPath, "test.go")
-			bytes, err := ioutil.ReadFile(expectedOutputFile)
-			Ω(err).ShouldNot(HaveOccurred())
+		Context("rewrite only templated and interpolated strings from --i18n-strings-filename", func() {
+			BeforeEach(func() {
+				dir, err := os.Getwd()
+				Ω(err).ShouldNot(HaveOccurred())
 
-			expectedOutput := string(bytes)
+				rootPath = filepath.Join(dir, "..", "..")
 
-			generatedOutputFile := filepath.Join(outputDir, "test.go")
-			bytes, err = ioutil.ReadFile(generatedOutputFile)
-			Ω(err).ShouldNot(HaveOccurred())
+				outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
+				Ω(err).ShouldNot(HaveOccurred())
 
-			actualOutput := string(bytes)
-			Ω(actualOutput).Should(Equal(expectedOutput))
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
+				inputFilesPath = filepath.Join(fixturesPath, "d_option", "input_files")
+				expectedFilesPath = filepath.Join(fixturesPath, "d_option", "expected_output")
+
+				err = os.MkdirAll(filepath.Join(outputDir, "doption"), 0777)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				CopyFile(filepath.Join(expectedFilesPath, "doption", "_test.go.en.json"), filepath.Join(outputDir, "doption", "test.go.en.json"))
+
+				session := Runi18n("-c",
+					"rewrite-package",
+					"-d", inputFilesPath,
+					"-o", outputDir,
+					"--ignore-regexp", "^[.]\\w+.go$", //Ignoring .*.go files, otherwise it defaults to ignoring *test*.go
+					"-v",
+				)
+
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			It("adds T() callExprs wrapping string literals", func() {
+				expectedOutputFile := filepath.Join(expectedFilesPath, "test.go")
+				generatedOutputFile := filepath.Join(outputDir, "test.go")
+				CompareExpectedOutputToGeneratedOutput(expectedOutputFile, generatedOutputFile)
+			})
 		})
 
-		It("recurses to files in nested dirs", func() {
-			expectedOutputFile := filepath.Join(expectedFilesPath, "nested_dir", "test.go")
-			bytes, err := ioutil.ReadFile(expectedOutputFile)
-			Ω(err).ShouldNot(HaveOccurred())
+		Context("rewrite only templated and interpolated strings from --i18n-strings-filename with multiple files", func() {
+			BeforeEach(func() {
+				dir, err := os.Getwd()
+				Ω(err).ShouldNot(HaveOccurred())
 
-			expectedOutput := string(bytes)
+				rootPath = filepath.Join(dir, "..", "..")
 
-			generatedOutputFile := filepath.Join(outputDir, "nested_dir", "test.go")
-			bytes, err = ioutil.ReadFile(generatedOutputFile)
-			Ω(err).ShouldNot(HaveOccurred())
+				outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
+				Ω(err).ShouldNot(HaveOccurred())
 
-			actualOutput := string(bytes)
-			Ω(actualOutput).Should(Equal(expectedOutput))
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
+				inputFilesPath = filepath.Join(fixturesPath, "d_option", "input_files")
+				expectedFilesPath = filepath.Join(fixturesPath, "d_option", "expected_output")
+
+				err = os.MkdirAll(filepath.Join(outputDir, "doption"), 0777)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				CopyFile(filepath.Join(expectedFilesPath, "doption", "_en.all.json"), filepath.Join(outputDir, "doption", "en.all.json"))
+
+				session := Runi18n("-c",
+					"rewrite-package",
+					"-d", inputFilesPath,
+					"-o", outputDir,
+					"--ignore-regexp", "^[.]\\w+.go$", //Ignoring .*.go files, otherwise it defaults to ignoring *test*.go
+					"--i18n-strings-filename", filepath.Join(expectedFilesPath, "doption", "en.all.json"),
+					"-v",
+				)
+
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			It("not adds T() callExprs wrapping string literals to test3.go since none are in JSON", func() {
+				expectedOutputFile := filepath.Join(expectedFilesPath, "test3.go")
+				generatedOutputFile := filepath.Join(outputDir, "test3.go")
+				CompareExpectedOutputToGeneratedOutput(expectedOutputFile, generatedOutputFile)
+			})
 		})
 
-		It("adds a i18n_init.go per package", func() {
-			initFile := filepath.Join(outputDir, "i18n_init.go")
-			expectedBytes, err := ioutil.ReadFile(initFile)
-			Ω(err).ShouldNot(HaveOccurred())
-			expected := strings.TrimSpace(string(expectedBytes))
+		Context("rewrite only templated and interpolated strings from --i18n-strings-dirname", func() {
+			BeforeEach(func() {
+				dir, err := os.Getwd()
+				Ω(err).ShouldNot(HaveOccurred())
 
-			expectedInitFile := filepath.Join(expectedFilesPath, "i18n_init.go")
-			actualBytes, err := ioutil.ReadFile(expectedInitFile)
-			Ω(err).ShouldNot(HaveOccurred())
-			actual := strings.TrimSpace(string(actualBytes))
+				rootPath = filepath.Join(dir, "..", "..")
 
-			Ω(actual).Should(Equal(expected))
+				outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
+				Ω(err).ShouldNot(HaveOccurred())
 
-			initFile = filepath.Join(outputDir, "nested_dir", "i18n_init.go")
-			expectedBytes, err = ioutil.ReadFile(initFile)
-			Ω(err).ShouldNot(HaveOccurred())
-			expected = strings.TrimSpace(string(expectedBytes))
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
+				inputFilesPath = filepath.Join(fixturesPath, "d_option", "input_files")
+				expectedFilesPath = filepath.Join(fixturesPath, "d_option", "expected_output")
 
-			expectedInitFile = filepath.Join(expectedFilesPath, "nested_dir", "i18n_init.go")
-			actualBytes, err = ioutil.ReadFile(expectedInitFile)
-			Ω(err).ShouldNot(HaveOccurred())
-			actual = strings.TrimSpace(string(actualBytes))
+				err = os.MkdirAll(filepath.Join(outputDir, "doption"), 0777)
+				Ω(err).ShouldNot(HaveOccurred())
 
-			Ω(actual).Should(Equal(expected))
+				CopyFile(filepath.Join(expectedFilesPath, "doption", "_test.go.en.json"), filepath.Join(outputDir, "doption", "test.go.en.json"))
+				CopyFile(filepath.Join(expectedFilesPath, "doption", "_test2.go.en.json"), filepath.Join(outputDir, "doption", "test2.go.en.json"))
+
+				session := Runi18n("-c",
+					"rewrite-package",
+					"-d", inputFilesPath,
+					"-o", outputDir,
+					"--ignore-regexp", "^[.]\\w+.go$", //Ignoring .*.go files, otherwise it defaults to ignoring *test*.go
+					"-v",
+				)
+
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			It("adds T() callExprs wrapping string literals for all sources in the directory", func() {
+				expectedOutputFile := filepath.Join(expectedFilesPath, "test.go")
+				generatedOutputFile := filepath.Join(outputDir, "test.go")
+				CompareExpectedOutputToGeneratedOutput(expectedOutputFile, generatedOutputFile)
+
+				expectedOutputFile = filepath.Join(expectedFilesPath, "test2.go")
+				generatedOutputFile = filepath.Join(outputDir, "test2.go")
+				CompareExpectedOutputToGeneratedOutput(expectedOutputFile, generatedOutputFile)
+			})
 		})
 
-		It("does not translate test files", func() {
-			_, doesFileExistErr := os.Stat(filepath.Join(outputDir, "a_really_bad_test.go"))
-			Ω(os.IsNotExist(doesFileExistErr)).Should(BeTrue())
-		})
 	})
 
-	Context("rewrite only templated and interpolated strings from --i18n-strings-filename", func() {
-		BeforeEach(func() {
-			dir, err := os.Getwd()
-			Ω(err).ShouldNot(HaveOccurred())
+	Context("Using cobra commands", func() {
+		Context("rewrite all templated and interpolated strings", func() {
+			BeforeEach(func() {
+				dir, err := os.Getwd()
+				Ω(err).ShouldNot(HaveOccurred())
 
-			rootPath = filepath.Join(dir, "..", "..")
+				rootPath = filepath.Join(dir, "..", "..")
 
-			outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
-			Ω(err).ShouldNot(HaveOccurred())
+				outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
+				Ω(err).ShouldNot(HaveOccurred())
 
-			fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
-			inputFilesPath = filepath.Join(fixturesPath, "d_option", "input_files")
-			expectedFilesPath = filepath.Join(fixturesPath, "d_option", "expected_output")
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
+				inputFilesPath = filepath.Join(fixturesPath, "f_option", "input_files")
+				expectedFilesPath = filepath.Join(fixturesPath, "f_option", "expected_output")
 
-			err = os.MkdirAll(filepath.Join(outputDir, "doption"), 0777)
-			Ω(err).ShouldNot(HaveOccurred())
+				session := Runi18n("rewrite-package",
+					"-d", inputFilesPath,
+					"-o", outputDir,
+					"--ignore-regexp", "^[.]\\w+.go$", //Ignoring .*.go files, otherwise it defaults to ignoring *test*.go
+					"--root-path", rootPath,
+					"-r",
+					"-v",
+				)
 
-			CopyFile(filepath.Join(expectedFilesPath, "doption", "_test.go.en.json"), filepath.Join(outputDir, "doption", "test.go.en.json"))
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
 
-			session := Runi18n("-c",
-				"rewrite-package",
-				"-d", inputFilesPath,
-				"-o", outputDir,
-				"--ignore-regexp", "^[.]\\w+.go$", //Ignoring .*.go files, otherwise it defaults to ignoring *test*.go
-				"-v",
-			)
+			It("adds T() callExprs wrapping string literals", func() {
+				expectedOutputFile := filepath.Join(expectedFilesPath, "test.go")
+				bytes, err := ioutil.ReadFile(expectedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
 
-			Ω(session.ExitCode()).Should(Equal(0))
+				expectedOutput := string(bytes)
+
+				generatedOutputFile := filepath.Join(outputDir, "test.go")
+				bytes, err = ioutil.ReadFile(generatedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				actualOutput := string(bytes)
+				Ω(actualOutput).Should(Equal(expectedOutput))
+			})
+
+			It("recurses to files in nested dirs", func() {
+				expectedOutputFile := filepath.Join(expectedFilesPath, "nested_dir", "test.go")
+				bytes, err := ioutil.ReadFile(expectedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				expectedOutput := string(bytes)
+
+				generatedOutputFile := filepath.Join(outputDir, "nested_dir", "test.go")
+				bytes, err = ioutil.ReadFile(generatedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				actualOutput := string(bytes)
+				Ω(actualOutput).Should(Equal(expectedOutput))
+			})
+
+			It("adds a i18n_init.go per package", func() {
+				initFile := filepath.Join(outputDir, "i18n_init.go")
+				expectedBytes, err := ioutil.ReadFile(initFile)
+				Ω(err).ShouldNot(HaveOccurred())
+				expected := strings.TrimSpace(string(expectedBytes))
+
+				expectedInitFile := filepath.Join(expectedFilesPath, "i18n_init.go")
+				actualBytes, err := ioutil.ReadFile(expectedInitFile)
+				Ω(err).ShouldNot(HaveOccurred())
+				actual := strings.TrimSpace(string(actualBytes))
+
+				Ω(actual).Should(Equal(expected))
+
+				initFile = filepath.Join(outputDir, "nested_dir", "i18n_init.go")
+				expectedBytes, err = ioutil.ReadFile(initFile)
+				Ω(err).ShouldNot(HaveOccurred())
+				expected = strings.TrimSpace(string(expectedBytes))
+
+				expectedInitFile = filepath.Join(expectedFilesPath, "nested_dir", "i18n_init.go")
+				actualBytes, err = ioutil.ReadFile(expectedInitFile)
+				Ω(err).ShouldNot(HaveOccurred())
+				actual = strings.TrimSpace(string(actualBytes))
+
+				Ω(actual).Should(Equal(expected))
+			})
+
+			It("does not translate test files", func() {
+				_, doesFileExistErr := os.Stat(filepath.Join(outputDir, "a_really_bad_test.go"))
+				Ω(os.IsNotExist(doesFileExistErr)).Should(BeTrue())
+			})
 		})
 
-		It("adds T() callExprs wrapping string literals", func() {
-			expectedOutputFile := filepath.Join(expectedFilesPath, "test.go")
-			generatedOutputFile := filepath.Join(outputDir, "test.go")
-			CompareExpectedOutputToGeneratedOutput(expectedOutputFile, generatedOutputFile)
-		})
-	})
+		Context("rewrite only templated and interpolated strings from --i18n-strings-filename", func() {
+			BeforeEach(func() {
+				dir, err := os.Getwd()
+				Ω(err).ShouldNot(HaveOccurred())
 
-	Context("rewrite only templated and interpolated strings from --i18n-strings-filename with multiple files", func() {
-		BeforeEach(func() {
-			dir, err := os.Getwd()
-			Ω(err).ShouldNot(HaveOccurred())
+				rootPath = filepath.Join(dir, "..", "..")
 
-			rootPath = filepath.Join(dir, "..", "..")
+				outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
+				Ω(err).ShouldNot(HaveOccurred())
 
-			outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
-			Ω(err).ShouldNot(HaveOccurred())
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
+				inputFilesPath = filepath.Join(fixturesPath, "d_option", "input_files")
+				expectedFilesPath = filepath.Join(fixturesPath, "d_option", "expected_output")
 
-			fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
-			inputFilesPath = filepath.Join(fixturesPath, "d_option", "input_files")
-			expectedFilesPath = filepath.Join(fixturesPath, "d_option", "expected_output")
+				err = os.MkdirAll(filepath.Join(outputDir, "doption"), 0777)
+				Ω(err).ShouldNot(HaveOccurred())
 
-			err = os.MkdirAll(filepath.Join(outputDir, "doption"), 0777)
-			Ω(err).ShouldNot(HaveOccurred())
+				CopyFile(filepath.Join(expectedFilesPath, "doption", "_test.go.en.json"), filepath.Join(outputDir, "doption", "test.go.en.json"))
 
-			CopyFile(filepath.Join(expectedFilesPath, "doption", "_en.all.json"), filepath.Join(outputDir, "doption", "en.all.json"))
+				session := Runi18n("rewrite-package",
+					"-d", inputFilesPath,
+					"-o", outputDir,
+					"--ignore-regexp", "^[.]\\w+.go$", //Ignoring .*.go files, otherwise it defaults to ignoring *test*.go
+					"-v",
+				)
 
-			session := Runi18n("-c",
-				"rewrite-package",
-				"-d", inputFilesPath,
-				"-o", outputDir,
-				"--ignore-regexp", "^[.]\\w+.go$", //Ignoring .*.go files, otherwise it defaults to ignoring *test*.go
-				"--i18n-strings-filename", filepath.Join(expectedFilesPath, "doption", "en.all.json"),
-				"-v",
-			)
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
 
-			Ω(session.ExitCode()).Should(Equal(0))
+			It("adds T() callExprs wrapping string literals", func() {
+				expectedOutputFile := filepath.Join(expectedFilesPath, "test.go")
+				generatedOutputFile := filepath.Join(outputDir, "test.go")
+				CompareExpectedOutputToGeneratedOutput(expectedOutputFile, generatedOutputFile)
+			})
 		})
 
-		It("not adds T() callExprs wrapping string literals to test3.go since none are in JSON", func() {
-			expectedOutputFile := filepath.Join(expectedFilesPath, "test3.go")
-			generatedOutputFile := filepath.Join(outputDir, "test3.go")
-			CompareExpectedOutputToGeneratedOutput(expectedOutputFile, generatedOutputFile)
+		Context("rewrite only templated and interpolated strings from --i18n-strings-filename with multiple files", func() {
+			BeforeEach(func() {
+				dir, err := os.Getwd()
+				Ω(err).ShouldNot(HaveOccurred())
+
+				rootPath = filepath.Join(dir, "..", "..")
+
+				outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
+				Ω(err).ShouldNot(HaveOccurred())
+
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
+				inputFilesPath = filepath.Join(fixturesPath, "d_option", "input_files")
+				expectedFilesPath = filepath.Join(fixturesPath, "d_option", "expected_output")
+
+				err = os.MkdirAll(filepath.Join(outputDir, "doption"), 0777)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				CopyFile(filepath.Join(expectedFilesPath, "doption", "_en.all.json"), filepath.Join(outputDir, "doption", "en.all.json"))
+
+				session := Runi18n("rewrite-package",
+					"-d", inputFilesPath,
+					"-o", outputDir,
+					"--ignore-regexp", "^[.]\\w+.go$", //Ignoring .*.go files, otherwise it defaults to ignoring *test*.go
+					"--i18n-strings-filename", filepath.Join(expectedFilesPath, "doption", "en.all.json"),
+					"-v",
+				)
+
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			It("not adds T() callExprs wrapping string literals to test3.go since none are in JSON", func() {
+				expectedOutputFile := filepath.Join(expectedFilesPath, "test3.go")
+				generatedOutputFile := filepath.Join(outputDir, "test3.go")
+				CompareExpectedOutputToGeneratedOutput(expectedOutputFile, generatedOutputFile)
+			})
 		})
-	})
 
-	Context("rewrite only templated and interpolated strings from --i18n-strings-dirname", func() {
-		BeforeEach(func() {
-			dir, err := os.Getwd()
-			Ω(err).ShouldNot(HaveOccurred())
+		Context("rewrite only templated and interpolated strings from --i18n-strings-dirname", func() {
+			BeforeEach(func() {
+				dir, err := os.Getwd()
+				Ω(err).ShouldNot(HaveOccurred())
 
-			rootPath = filepath.Join(dir, "..", "..")
+				rootPath = filepath.Join(dir, "..", "..")
 
-			outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
-			Ω(err).ShouldNot(HaveOccurred())
+				outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
+				Ω(err).ShouldNot(HaveOccurred())
 
-			fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
-			inputFilesPath = filepath.Join(fixturesPath, "d_option", "input_files")
-			expectedFilesPath = filepath.Join(fixturesPath, "d_option", "expected_output")
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
+				inputFilesPath = filepath.Join(fixturesPath, "d_option", "input_files")
+				expectedFilesPath = filepath.Join(fixturesPath, "d_option", "expected_output")
 
-			err = os.MkdirAll(filepath.Join(outputDir, "doption"), 0777)
-			Ω(err).ShouldNot(HaveOccurred())
+				err = os.MkdirAll(filepath.Join(outputDir, "doption"), 0777)
+				Ω(err).ShouldNot(HaveOccurred())
 
-			CopyFile(filepath.Join(expectedFilesPath, "doption", "_test.go.en.json"), filepath.Join(outputDir, "doption", "test.go.en.json"))
-			CopyFile(filepath.Join(expectedFilesPath, "doption", "_test2.go.en.json"), filepath.Join(outputDir, "doption", "test2.go.en.json"))
+				CopyFile(filepath.Join(expectedFilesPath, "doption", "_test.go.en.json"), filepath.Join(outputDir, "doption", "test.go.en.json"))
+				CopyFile(filepath.Join(expectedFilesPath, "doption", "_test2.go.en.json"), filepath.Join(outputDir, "doption", "test2.go.en.json"))
 
-			session := Runi18n("-c",
-				"rewrite-package",
-				"-d", inputFilesPath,
-				"-o", outputDir,
-				"--ignore-regexp", "^[.]\\w+.go$", //Ignoring .*.go files, otherwise it defaults to ignoring *test*.go
-				"-v",
-			)
+				session := Runi18n("rewrite-package",
+					"-d", inputFilesPath,
+					"-o", outputDir,
+					"--ignore-regexp", "^[.]\\w+.go$", //Ignoring .*.go files, otherwise it defaults to ignoring *test*.go
+					"-v",
+				)
 
-			Ω(session.ExitCode()).Should(Equal(0))
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			It("adds T() callExprs wrapping string literals for all sources in the directory", func() {
+				expectedOutputFile := filepath.Join(expectedFilesPath, "test.go")
+				generatedOutputFile := filepath.Join(outputDir, "test.go")
+				CompareExpectedOutputToGeneratedOutput(expectedOutputFile, generatedOutputFile)
+
+				expectedOutputFile = filepath.Join(expectedFilesPath, "test2.go")
+				generatedOutputFile = filepath.Join(outputDir, "test2.go")
+				CompareExpectedOutputToGeneratedOutput(expectedOutputFile, generatedOutputFile)
+			})
 		})
 
-		It("adds T() callExprs wrapping string literals for all sources in the directory", func() {
-			expectedOutputFile := filepath.Join(expectedFilesPath, "test.go")
-			generatedOutputFile := filepath.Join(outputDir, "test.go")
-			CompareExpectedOutputToGeneratedOutput(expectedOutputFile, generatedOutputFile)
-
-			expectedOutputFile = filepath.Join(expectedFilesPath, "test2.go")
-			generatedOutputFile = filepath.Join(outputDir, "test2.go")
-			CompareExpectedOutputToGeneratedOutput(expectedOutputFile, generatedOutputFile)
-		})
 	})
 })

--- a/integration/rewrite_package/f_option_test.go
+++ b/integration/rewrite_package/f_option_test.go
@@ -39,186 +39,374 @@ var _ = Describe("rewrite-package -f filename", func() {
 		Ω(err).ShouldNot(HaveOccurred())
 	})
 
-	Context("no -o option passed, so input file is rewritten", func() {
-		BeforeEach(func() {
-			dir, err := os.Getwd()
-			Ω(err).ShouldNot(HaveOccurred())
-			rootPath = filepath.Join(dir, "..", "..")
+	Context("Using legacy commands", func() {
 
-			outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
-			Ω(err).ShouldNot(HaveOccurred())
+		Context("no -o option passed, so input file is rewritten", func() {
+			BeforeEach(func() {
+				dir, err := os.Getwd()
+				Ω(err).ShouldNot(HaveOccurred())
+				rootPath = filepath.Join(dir, "..", "..")
 
-			fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
-			inputFilesPath = filepath.Join(fixturesPath, "f_option", "input_files")
-			expectedFilesPath = filepath.Join(fixturesPath, "f_option", "expected_output")
+				outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
+				Ω(err).ShouldNot(HaveOccurred())
 
-			CopyFile(filepath.Join(inputFilesPath, "test.go"), filepath.Join(outputDir, "test.go"))
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
+				inputFilesPath = filepath.Join(fixturesPath, "f_option", "input_files")
+				expectedFilesPath = filepath.Join(fixturesPath, "f_option", "expected_output")
 
-			session := Runi18n("-c", "rewrite-package",
-				"-f", filepath.Join(outputDir, "test.go"),
-				"--root-path", outputDir,
-				"-v",
-			)
+				CopyFile(filepath.Join(inputFilesPath, "test.go"), filepath.Join(outputDir, "test.go"))
 
-			Ω(session.ExitCode()).Should(Equal(0))
+				session := Runi18n("-c", "rewrite-package",
+					"-f", filepath.Join(outputDir, "test.go"),
+					"--root-path", outputDir,
+					"-v",
+				)
+
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			It("overwrites the input file with T() wrappers around strings", func() {
+				expectedOutputFile := filepath.Join(expectedFilesPath, "test.go")
+				bytes, err := ioutil.ReadFile(expectedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				expectedOutput := string(bytes)
+
+				generatedOutputFile := filepath.Join(outputDir, "test.go")
+				bytes, err = ioutil.ReadFile(generatedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				actualOutput := string(bytes)
+
+				Ω(actualOutput).Should(Equal(expectedOutput))
+			})
+
+			It("adds T func declaration and i18n init() func in the same directory as input file", func() {
+				initFile := filepath.Join(outputDir, "i18n_init.go")
+				expectedBytes, err := ioutil.ReadFile(initFile)
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(expectedBytes).ShouldNot(Equal(""))
+			})
 		})
 
-		It("overwrites the input file with T() wrappers around strings", func() {
-			expectedOutputFile := filepath.Join(expectedFilesPath, "test.go")
-			bytes, err := ioutil.ReadFile(expectedOutputFile)
-			Ω(err).ShouldNot(HaveOccurred())
+		Context("all strings to rewrite are simple strings", func() {
+			BeforeEach(func() {
+				dir, err := os.Getwd()
+				Ω(err).ShouldNot(HaveOccurred())
+				rootPath = filepath.Join(dir, "..", "..")
 
-			expectedOutput := string(bytes)
+				outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
+				Ω(err).ShouldNot(HaveOccurred())
 
-			generatedOutputFile := filepath.Join(outputDir, "test.go")
-			bytes, err = ioutil.ReadFile(generatedOutputFile)
-			Ω(err).ShouldNot(HaveOccurred())
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
+				inputFilesPath = filepath.Join(fixturesPath, "f_option", "input_files")
+				expectedFilesPath = filepath.Join(fixturesPath, "f_option", "expected_output")
 
-			actualOutput := string(bytes)
+				session := Runi18n("-c",
+					"rewrite-package",
+					"-f", filepath.Join(inputFilesPath, "test.go"),
+					"-o", outputDir,
+					"--root-path", rootPath,
+					"-v",
+				)
 
-			Ω(actualOutput).Should(Equal(expectedOutput))
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			It("rewrites the input file with T() wrappers around strings", func() {
+				expectedOutputFile := filepath.Join(expectedFilesPath, "test.go")
+				bytes, err := ioutil.ReadFile(expectedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				expectedOutput := string(bytes)
+
+				generatedOutputFile := filepath.Join(outputDir, "test.go")
+				bytes, err = ioutil.ReadFile(generatedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				actualOutput := string(bytes)
+
+				Ω(actualOutput).Should(Equal(expectedOutput))
+			})
+
+			It("adds T func declaration and i18n init() func", func() {
+				initFile := filepath.Join(outputDir, "i18n_init.go")
+				expectedBytes, err := ioutil.ReadFile(initFile)
+				Ω(err).ShouldNot(HaveOccurred())
+				expected := strings.TrimSpace(string(expectedBytes))
+
+				expectedInitFile := filepath.Join(expectedFilesPath, "i18n_init.go")
+				actualBytes, err := ioutil.ReadFile(expectedInitFile)
+				Ω(err).ShouldNot(HaveOccurred())
+				actual := strings.TrimSpace(string(actualBytes))
+
+				Ω(actual).Should(Equal(expected))
+			})
 		})
 
-		It("adds T func declaration and i18n init() func in the same directory as input file", func() {
-			initFile := filepath.Join(outputDir, "i18n_init.go")
-			expectedBytes, err := ioutil.ReadFile(initFile)
-			Ω(err).ShouldNot(HaveOccurred())
-			Ω(expectedBytes).ShouldNot(Equal(""))
+		Context("strings to rewrite contain complex templated strings", func() {
+			BeforeEach(func() {
+				dir, err := os.Getwd()
+				Ω(err).ShouldNot(HaveOccurred())
+				rootPath = filepath.Join(dir, "..", "..")
+
+				outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
+				Ω(err).ShouldNot(HaveOccurred())
+
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
+				inputFilesPath = filepath.Join(fixturesPath, "f_option", "input_files")
+				expectedFilesPath = filepath.Join(fixturesPath, "f_option", "expected_output")
+
+				session := Runi18n("-c",
+					"rewrite-package",
+					"-f", filepath.Join(inputFilesPath, "test_templated_strings.go"),
+					"-o", filepath.Join(outputDir),
+					"-v",
+				)
+
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			It("rewrites the input file with T() wrappers around all (simple and templated) strings", func() {
+				expectedOutputFile := filepath.Join(expectedFilesPath, "test_templated_strings.go")
+				bytes, err := ioutil.ReadFile(expectedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				expectedOutput := string(bytes)
+
+				generatedOutputFile := filepath.Join(outputDir, "test_templated_strings.go")
+				bytes, err = ioutil.ReadFile(generatedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				actualOutput := string(bytes)
+
+				Ω(actualOutput).Should(Equal(expectedOutput))
+			})
 		})
+
+		Context("strings to rewrite contain interpolated strings", func() {
+			BeforeEach(func() {
+				dir, err := os.Getwd()
+				Ω(err).ShouldNot(HaveOccurred())
+				rootPath = filepath.Join(dir, "..", "..")
+
+				outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
+				Ω(err).ShouldNot(HaveOccurred())
+
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
+				inputFilesPath = filepath.Join(fixturesPath, "f_option", "input_files")
+				expectedFilesPath = filepath.Join(fixturesPath, "f_option", "expected_output")
+
+				session := Runi18n("-c",
+					"rewrite-package",
+					"-f", filepath.Join(inputFilesPath, "test_interpolated_strings.go"),
+					"-o", filepath.Join(outputDir),
+					"-v",
+				)
+
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			It("converts interpolated strings to templated and rewrites the input file with T() wrappers around all (simple and templated) strings", func() {
+				expectedOutputFile := filepath.Join(expectedFilesPath, "test_interpolated_strings.go")
+				bytes, err := ioutil.ReadFile(expectedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				expectedOutput := string(bytes)
+
+				generatedOutputFile := filepath.Join(outputDir, "test_interpolated_strings.go")
+				bytes, err = ioutil.ReadFile(generatedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				actualOutput := string(bytes)
+
+				Ω(actualOutput).Should(Equal(expectedOutput))
+			})
+		})
+
 	})
 
-	Context("all strings to rewrite are simple strings", func() {
-		BeforeEach(func() {
-			dir, err := os.Getwd()
-			Ω(err).ShouldNot(HaveOccurred())
-			rootPath = filepath.Join(dir, "..", "..")
+	Context("Using cobra commands", func() {
 
-			outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
-			Ω(err).ShouldNot(HaveOccurred())
+		Context("no -o option passed, so input file is rewritten", func() {
+			BeforeEach(func() {
+				dir, err := os.Getwd()
+				Ω(err).ShouldNot(HaveOccurred())
+				rootPath = filepath.Join(dir, "..", "..")
 
-			fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
-			inputFilesPath = filepath.Join(fixturesPath, "f_option", "input_files")
-			expectedFilesPath = filepath.Join(fixturesPath, "f_option", "expected_output")
+				outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
+				Ω(err).ShouldNot(HaveOccurred())
 
-			session := Runi18n("-c",
-				"rewrite-package",
-				"-f", filepath.Join(inputFilesPath, "test.go"),
-				"-o", outputDir,
-				"--root-path", rootPath,
-				"-v",
-			)
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
+				inputFilesPath = filepath.Join(fixturesPath, "f_option", "input_files")
+				expectedFilesPath = filepath.Join(fixturesPath, "f_option", "expected_output")
 
-			Ω(session.ExitCode()).Should(Equal(0))
+				CopyFile(filepath.Join(inputFilesPath, "test.go"), filepath.Join(outputDir, "test.go"))
+
+				session := Runi18n("rewrite-package",
+					"-f", filepath.Join(outputDir, "test.go"),
+					"--root-path", outputDir,
+					"-v",
+				)
+
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			It("overwrites the input file with T() wrappers around strings", func() {
+				expectedOutputFile := filepath.Join(expectedFilesPath, "test.go")
+				bytes, err := ioutil.ReadFile(expectedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				expectedOutput := string(bytes)
+
+				generatedOutputFile := filepath.Join(outputDir, "test.go")
+				bytes, err = ioutil.ReadFile(generatedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				actualOutput := string(bytes)
+
+				Ω(actualOutput).Should(Equal(expectedOutput))
+			})
+
+			It("adds T func declaration and i18n init() func in the same directory as input file", func() {
+				initFile := filepath.Join(outputDir, "i18n_init.go")
+				expectedBytes, err := ioutil.ReadFile(initFile)
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(expectedBytes).ShouldNot(Equal(""))
+			})
 		})
 
-		It("rewrites the input file with T() wrappers around strings", func() {
-			expectedOutputFile := filepath.Join(expectedFilesPath, "test.go")
-			bytes, err := ioutil.ReadFile(expectedOutputFile)
-			Ω(err).ShouldNot(HaveOccurred())
+		Context("all strings to rewrite are simple strings", func() {
+			BeforeEach(func() {
+				dir, err := os.Getwd()
+				Ω(err).ShouldNot(HaveOccurred())
+				rootPath = filepath.Join(dir, "..", "..")
 
-			expectedOutput := string(bytes)
+				outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
+				Ω(err).ShouldNot(HaveOccurred())
 
-			generatedOutputFile := filepath.Join(outputDir, "test.go")
-			bytes, err = ioutil.ReadFile(generatedOutputFile)
-			Ω(err).ShouldNot(HaveOccurred())
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
+				inputFilesPath = filepath.Join(fixturesPath, "f_option", "input_files")
+				expectedFilesPath = filepath.Join(fixturesPath, "f_option", "expected_output")
 
-			actualOutput := string(bytes)
+				session := Runi18n("rewrite-package",
+					"-f", filepath.Join(inputFilesPath, "test.go"),
+					"-o", outputDir,
+					"--root-path", rootPath,
+					"-v",
+				)
 
-			Ω(actualOutput).Should(Equal(expectedOutput))
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			It("rewrites the input file with T() wrappers around strings", func() {
+				expectedOutputFile := filepath.Join(expectedFilesPath, "test.go")
+				bytes, err := ioutil.ReadFile(expectedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				expectedOutput := string(bytes)
+
+				generatedOutputFile := filepath.Join(outputDir, "test.go")
+				bytes, err = ioutil.ReadFile(generatedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				actualOutput := string(bytes)
+
+				Ω(actualOutput).Should(Equal(expectedOutput))
+			})
+
+			It("adds T func declaration and i18n init() func", func() {
+				initFile := filepath.Join(outputDir, "i18n_init.go")
+				expectedBytes, err := ioutil.ReadFile(initFile)
+				Ω(err).ShouldNot(HaveOccurred())
+				expected := strings.TrimSpace(string(expectedBytes))
+
+				expectedInitFile := filepath.Join(expectedFilesPath, "i18n_init.go")
+				actualBytes, err := ioutil.ReadFile(expectedInitFile)
+				Ω(err).ShouldNot(HaveOccurred())
+				actual := strings.TrimSpace(string(actualBytes))
+
+				Ω(actual).Should(Equal(expected))
+			})
 		})
 
-		It("adds T func declaration and i18n init() func", func() {
-			initFile := filepath.Join(outputDir, "i18n_init.go")
-			expectedBytes, err := ioutil.ReadFile(initFile)
-			Ω(err).ShouldNot(HaveOccurred())
-			expected := strings.TrimSpace(string(expectedBytes))
+		Context("strings to rewrite contain complex templated strings", func() {
+			BeforeEach(func() {
+				dir, err := os.Getwd()
+				Ω(err).ShouldNot(HaveOccurred())
+				rootPath = filepath.Join(dir, "..", "..")
 
-			expectedInitFile := filepath.Join(expectedFilesPath, "i18n_init.go")
-			actualBytes, err := ioutil.ReadFile(expectedInitFile)
-			Ω(err).ShouldNot(HaveOccurred())
-			actual := strings.TrimSpace(string(actualBytes))
+				outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
+				Ω(err).ShouldNot(HaveOccurred())
 
-			Ω(actual).Should(Equal(expected))
-		})
-	})
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
+				inputFilesPath = filepath.Join(fixturesPath, "f_option", "input_files")
+				expectedFilesPath = filepath.Join(fixturesPath, "f_option", "expected_output")
 
-	Context("strings to rewrite contain complex templated strings", func() {
-		BeforeEach(func() {
-			dir, err := os.Getwd()
-			Ω(err).ShouldNot(HaveOccurred())
-			rootPath = filepath.Join(dir, "..", "..")
+				session := Runi18n("rewrite-package",
+					"-f", filepath.Join(inputFilesPath, "test_templated_strings.go"),
+					"-o", filepath.Join(outputDir),
+					"-v",
+				)
 
-			outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
-			Ω(err).ShouldNot(HaveOccurred())
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
 
-			fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
-			inputFilesPath = filepath.Join(fixturesPath, "f_option", "input_files")
-			expectedFilesPath = filepath.Join(fixturesPath, "f_option", "expected_output")
+			It("rewrites the input file with T() wrappers around all (simple and templated) strings", func() {
+				expectedOutputFile := filepath.Join(expectedFilesPath, "test_templated_strings.go")
+				bytes, err := ioutil.ReadFile(expectedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
 
-			session := Runi18n("-c",
-				"rewrite-package",
-				"-f", filepath.Join(inputFilesPath, "test_templated_strings.go"),
-				"-o", filepath.Join(outputDir),
-				"-v",
-			)
+				expectedOutput := string(bytes)
 
-			Ω(session.ExitCode()).Should(Equal(0))
-		})
+				generatedOutputFile := filepath.Join(outputDir, "test_templated_strings.go")
+				bytes, err = ioutil.ReadFile(generatedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
 
-		It("rewrites the input file with T() wrappers around all (simple and templated) strings", func() {
-			expectedOutputFile := filepath.Join(expectedFilesPath, "test_templated_strings.go")
-			bytes, err := ioutil.ReadFile(expectedOutputFile)
-			Ω(err).ShouldNot(HaveOccurred())
+				actualOutput := string(bytes)
 
-			expectedOutput := string(bytes)
-
-			generatedOutputFile := filepath.Join(outputDir, "test_templated_strings.go")
-			bytes, err = ioutil.ReadFile(generatedOutputFile)
-			Ω(err).ShouldNot(HaveOccurred())
-
-			actualOutput := string(bytes)
-
-			Ω(actualOutput).Should(Equal(expectedOutput))
-		})
-	})
-
-	Context("strings to rewrite contain interpolated strings", func() {
-		BeforeEach(func() {
-			dir, err := os.Getwd()
-			Ω(err).ShouldNot(HaveOccurred())
-			rootPath = filepath.Join(dir, "..", "..")
-
-			outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
-			Ω(err).ShouldNot(HaveOccurred())
-
-			fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
-			inputFilesPath = filepath.Join(fixturesPath, "f_option", "input_files")
-			expectedFilesPath = filepath.Join(fixturesPath, "f_option", "expected_output")
-
-			session := Runi18n("-c",
-				"rewrite-package",
-				"-f", filepath.Join(inputFilesPath, "test_interpolated_strings.go"),
-				"-o", filepath.Join(outputDir),
-				"-v",
-			)
-
-			Ω(session.ExitCode()).Should(Equal(0))
+				Ω(actualOutput).Should(Equal(expectedOutput))
+			})
 		})
 
-		It("converts interpolated strings to templated and rewrites the input file with T() wrappers around all (simple and templated) strings", func() {
-			expectedOutputFile := filepath.Join(expectedFilesPath, "test_interpolated_strings.go")
-			bytes, err := ioutil.ReadFile(expectedOutputFile)
-			Ω(err).ShouldNot(HaveOccurred())
+		Context("strings to rewrite contain interpolated strings", func() {
+			BeforeEach(func() {
+				dir, err := os.Getwd()
+				Ω(err).ShouldNot(HaveOccurred())
+				rootPath = filepath.Join(dir, "..", "..")
 
-			expectedOutput := string(bytes)
+				outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
+				Ω(err).ShouldNot(HaveOccurred())
 
-			generatedOutputFile := filepath.Join(outputDir, "test_interpolated_strings.go")
-			bytes, err = ioutil.ReadFile(generatedOutputFile)
-			Ω(err).ShouldNot(HaveOccurred())
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
+				inputFilesPath = filepath.Join(fixturesPath, "f_option", "input_files")
+				expectedFilesPath = filepath.Join(fixturesPath, "f_option", "expected_output")
 
-			actualOutput := string(bytes)
+				session := Runi18n("rewrite-package",
+					"-f", filepath.Join(inputFilesPath, "test_interpolated_strings.go"),
+					"-o", filepath.Join(outputDir),
+					"-v",
+				)
 
-			Ω(actualOutput).Should(Equal(expectedOutput))
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			It("converts interpolated strings to templated and rewrites the input file with T() wrappers around all (simple and templated) strings", func() {
+				expectedOutputFile := filepath.Join(expectedFilesPath, "test_interpolated_strings.go")
+				bytes, err := ioutil.ReadFile(expectedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				expectedOutput := string(bytes)
+
+				generatedOutputFile := filepath.Join(outputDir, "test_interpolated_strings.go")
+				bytes, err = ioutil.ReadFile(generatedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				actualOutput := string(bytes)
+
+				Ω(actualOutput).Should(Equal(expectedOutput))
+			})
 		})
+
 	})
 })

--- a/integration/rewrite_package/i18n_strings_filename_test.go
+++ b/integration/rewrite_package/i18n_strings_filename_test.go
@@ -38,138 +38,279 @@ var _ = Describe("rewrite-package --i18n-strings-filename some-file", func() {
 		Ω(err).ShouldNot(HaveOccurred())
 	})
 
-	Context("input file only contains simple strings", func() {
-		BeforeEach(func() {
-			dir, err := os.Getwd()
-			Ω(err).ShouldNot(HaveOccurred())
-			rootPath = filepath.Join(dir, "..", "..")
+	Context("Using legacy commands", func() {
 
-			outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
-			Ω(err).ShouldNot(HaveOccurred())
+		Context("input file only contains simple strings", func() {
+			BeforeEach(func() {
+				dir, err := os.Getwd()
+				Ω(err).ShouldNot(HaveOccurred())
+				rootPath = filepath.Join(dir, "..", "..")
 
-			fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
-			inputFilesPath = filepath.Join(fixturesPath, "i18n_strings_filename_option", "input_files")
-			expectedFilesPath = filepath.Join(fixturesPath, "i18n_strings_filename_option", "expected_output")
+				outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
+				Ω(err).ShouldNot(HaveOccurred())
 
-			session := Runi18n("-c",
-				"rewrite-package",
-				"-f", filepath.Join(inputFilesPath, "test.go"),
-				"-o", outputDir,
-				"--i18n-strings-filename", filepath.Join(inputFilesPath, "strings.json"),
-				"-v",
-			)
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
+				inputFilesPath = filepath.Join(fixturesPath, "i18n_strings_filename_option", "input_files")
+				expectedFilesPath = filepath.Join(fixturesPath, "i18n_strings_filename_option", "expected_output")
 
-			Ω(session.ExitCode()).Should(Equal(0))
+				session := Runi18n("-c",
+					"rewrite-package",
+					"-f", filepath.Join(inputFilesPath, "test.go"),
+					"-o", outputDir,
+					"--i18n-strings-filename", filepath.Join(inputFilesPath, "strings.json"),
+					"-v",
+				)
+
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			It("rewrites the input file with T() wrappers around the strings specified in the --i18n-strings-filename flag", func() {
+				expectedOutputFile := filepath.Join(expectedFilesPath, "test.go")
+				bytes, err := ioutil.ReadFile(expectedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				expectedOutput := string(bytes)
+
+				generatedOutputFile := filepath.Join(outputDir, "test.go")
+				bytes, err = ioutil.ReadFile(generatedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				actualOutput := string(bytes)
+
+				Ω(actualOutput).Should(Equal(expectedOutput))
+			})
 		})
 
-		It("rewrites the input file with T() wrappers around the strings specified in the --i18n-strings-filename flag", func() {
-			expectedOutputFile := filepath.Join(expectedFilesPath, "test.go")
-			bytes, err := ioutil.ReadFile(expectedOutputFile)
-			Ω(err).ShouldNot(HaveOccurred())
+		Context("input file contains some templated strings", func() {
+			BeforeEach(func() {
+				dir, err := os.Getwd()
+				Ω(err).ShouldNot(HaveOccurred())
+				rootPath = filepath.Join(dir, "..", "..")
 
-			expectedOutput := string(bytes)
+				outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
+				Ω(err).ShouldNot(HaveOccurred())
 
-			generatedOutputFile := filepath.Join(outputDir, "test.go")
-			bytes, err = ioutil.ReadFile(generatedOutputFile)
-			Ω(err).ShouldNot(HaveOccurred())
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
+				inputFilesPath = filepath.Join(fixturesPath, "i18n_strings_filename_option", "input_files")
+				expectedFilesPath = filepath.Join(fixturesPath, "i18n_strings_filename_option", "expected_output")
 
-			actualOutput := string(bytes)
+				session := Runi18n("-c",
+					"rewrite-package",
+					"-f", filepath.Join(inputFilesPath, "test_templated_strings.go"),
+					"-o", outputDir,
+					"--i18n-strings-filename", filepath.Join(inputFilesPath, "test_templated_strings.go.en.json"),
+					"-v",
+				)
 
-			Ω(actualOutput).Should(Equal(expectedOutput))
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			It("rewrites the input file with T() wrappers around the strings (templated and not) specified in the --i18n-strings-filename flag", func() {
+				expectedOutputFile := filepath.Join(expectedFilesPath, "test_templated_strings.go")
+				bytes, err := ioutil.ReadFile(expectedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				expectedOutput := string(bytes)
+
+				generatedOutputFile := filepath.Join(outputDir, "test_templated_strings.go")
+				bytes, err = ioutil.ReadFile(generatedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				actualOutput := string(bytes)
+
+				Ω(actualOutput).Should(Equal(expectedOutput))
+			})
 		})
+
+		Context("input file contains some interpolated strings", func() {
+			BeforeEach(func() {
+				dir, err := os.Getwd()
+				Ω(err).ShouldNot(HaveOccurred())
+				rootPath = filepath.Join(dir, "..", "..")
+
+				outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
+				Ω(err).ShouldNot(HaveOccurred())
+
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
+				inputFilesPath = filepath.Join(fixturesPath, "i18n_strings_filename_option", "input_files")
+				expectedFilesPath = filepath.Join(fixturesPath, "i18n_strings_filename_option", "expected_output")
+
+				CopyFile(filepath.Join(inputFilesPath, "_test_interpolated_strings.go.en.json"), filepath.Join(inputFilesPath, "test_interpolated_strings.go.en.json"))
+
+				session := Runi18n("-c",
+					"rewrite-package",
+					"-f", filepath.Join(inputFilesPath, "test_interpolated_strings.go"),
+					"-o", outputDir,
+					"--i18n-strings-filename", filepath.Join(inputFilesPath, "test_interpolated_strings.go.en.json"),
+					"-v",
+				)
+
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			AfterEach(func() {
+				CopyFile(filepath.Join(inputFilesPath, "_test_interpolated_strings.go.en.json"), filepath.Join(inputFilesPath, "test_interpolated_strings.go.en.json"))
+			})
+
+			It("converts interpolated strings to templated and rewrites the input file with T() wrappers around the strings (templated and not) specified in the --i18n-strings-filename flag", func() {
+				expectedOutputFile := filepath.Join(expectedFilesPath, "test_interpolated_strings.go")
+				bytes, err := ioutil.ReadFile(expectedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				expectedOutput := string(bytes)
+
+				generatedOutputFile := filepath.Join(outputDir, "test_interpolated_strings.go")
+				bytes, err = ioutil.ReadFile(generatedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				actualOutput := string(bytes)
+
+				Ω(actualOutput).Should(Equal(expectedOutput))
+			})
+
+			It("updates the i18n strings JSON file with the converted interpolated JSON strings", func() {
+				expectedOutputFile := filepath.Join(expectedFilesPath, "test_interpolated_strings.go.en.json")
+				generatedOutputFile := filepath.Join(inputFilesPath, "test_interpolated_strings.go.en.json")
+				CompareExpectedToGeneratedTraslationJson(expectedOutputFile, generatedOutputFile)
+			})
+		})
+
 	})
 
-	Context("input file contains some templated strings", func() {
-		BeforeEach(func() {
-			dir, err := os.Getwd()
-			Ω(err).ShouldNot(HaveOccurred())
-			rootPath = filepath.Join(dir, "..", "..")
+	Context("Using cobra commands", func() {
 
-			outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
-			Ω(err).ShouldNot(HaveOccurred())
+		Context("input file only contains simple strings", func() {
+			BeforeEach(func() {
+				dir, err := os.Getwd()
+				Ω(err).ShouldNot(HaveOccurred())
+				rootPath = filepath.Join(dir, "..", "..")
 
-			fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
-			inputFilesPath = filepath.Join(fixturesPath, "i18n_strings_filename_option", "input_files")
-			expectedFilesPath = filepath.Join(fixturesPath, "i18n_strings_filename_option", "expected_output")
+				outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
+				Ω(err).ShouldNot(HaveOccurred())
 
-			session := Runi18n("-c",
-				"rewrite-package",
-				"-f", filepath.Join(inputFilesPath, "test_templated_strings.go"),
-				"-o", outputDir,
-				"--i18n-strings-filename", filepath.Join(inputFilesPath, "test_templated_strings.go.en.json"),
-				"-v",
-			)
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
+				inputFilesPath = filepath.Join(fixturesPath, "i18n_strings_filename_option", "input_files")
+				expectedFilesPath = filepath.Join(fixturesPath, "i18n_strings_filename_option", "expected_output")
 
-			Ω(session.ExitCode()).Should(Equal(0))
+				session := Runi18n("rewrite-package",
+					"-f", filepath.Join(inputFilesPath, "test.go"),
+					"-o", outputDir,
+					"--i18n-strings-filename", filepath.Join(inputFilesPath, "strings.json"),
+					"-v",
+				)
+
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			It("rewrites the input file with T() wrappers around the strings specified in the --i18n-strings-filename flag", func() {
+				expectedOutputFile := filepath.Join(expectedFilesPath, "test.go")
+				bytes, err := ioutil.ReadFile(expectedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				expectedOutput := string(bytes)
+
+				generatedOutputFile := filepath.Join(outputDir, "test.go")
+				bytes, err = ioutil.ReadFile(generatedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				actualOutput := string(bytes)
+
+				Ω(actualOutput).Should(Equal(expectedOutput))
+			})
 		})
 
-		It("rewrites the input file with T() wrappers around the strings (templated and not) specified in the --i18n-strings-filename flag", func() {
-			expectedOutputFile := filepath.Join(expectedFilesPath, "test_templated_strings.go")
-			bytes, err := ioutil.ReadFile(expectedOutputFile)
-			Ω(err).ShouldNot(HaveOccurred())
+		Context("input file contains some templated strings", func() {
+			BeforeEach(func() {
+				dir, err := os.Getwd()
+				Ω(err).ShouldNot(HaveOccurred())
+				rootPath = filepath.Join(dir, "..", "..")
 
-			expectedOutput := string(bytes)
+				outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
+				Ω(err).ShouldNot(HaveOccurred())
 
-			generatedOutputFile := filepath.Join(outputDir, "test_templated_strings.go")
-			bytes, err = ioutil.ReadFile(generatedOutputFile)
-			Ω(err).ShouldNot(HaveOccurred())
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
+				inputFilesPath = filepath.Join(fixturesPath, "i18n_strings_filename_option", "input_files")
+				expectedFilesPath = filepath.Join(fixturesPath, "i18n_strings_filename_option", "expected_output")
 
-			actualOutput := string(bytes)
+				session := Runi18n("-c",
+					"rewrite-package",
+					"-f", filepath.Join(inputFilesPath, "test_templated_strings.go"),
+					"-o", outputDir,
+					"--i18n-strings-filename", filepath.Join(inputFilesPath, "test_templated_strings.go.en.json"),
+					"-v",
+				)
 
-			Ω(actualOutput).Should(Equal(expectedOutput))
-		})
-	})
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
 
-	Context("input file contains some interpolated strings", func() {
-		BeforeEach(func() {
-			dir, err := os.Getwd()
-			Ω(err).ShouldNot(HaveOccurred())
-			rootPath = filepath.Join(dir, "..", "..")
+			It("rewrites the input file with T() wrappers around the strings (templated and not) specified in the --i18n-strings-filename flag", func() {
+				expectedOutputFile := filepath.Join(expectedFilesPath, "test_templated_strings.go")
+				bytes, err := ioutil.ReadFile(expectedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
 
-			outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
-			Ω(err).ShouldNot(HaveOccurred())
+				expectedOutput := string(bytes)
 
-			fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
-			inputFilesPath = filepath.Join(fixturesPath, "i18n_strings_filename_option", "input_files")
-			expectedFilesPath = filepath.Join(fixturesPath, "i18n_strings_filename_option", "expected_output")
+				generatedOutputFile := filepath.Join(outputDir, "test_templated_strings.go")
+				bytes, err = ioutil.ReadFile(generatedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
 
-			CopyFile(filepath.Join(inputFilesPath, "_test_interpolated_strings.go.en.json"), filepath.Join(inputFilesPath, "test_interpolated_strings.go.en.json"))
+				actualOutput := string(bytes)
 
-			session := Runi18n("-c",
-				"rewrite-package",
-				"-f", filepath.Join(inputFilesPath, "test_interpolated_strings.go"),
-				"-o", outputDir,
-				"--i18n-strings-filename", filepath.Join(inputFilesPath, "test_interpolated_strings.go.en.json"),
-				"-v",
-			)
-
-			Ω(session.ExitCode()).Should(Equal(0))
+				Ω(actualOutput).Should(Equal(expectedOutput))
+			})
 		})
 
-		AfterEach(func() {
-			CopyFile(filepath.Join(inputFilesPath, "_test_interpolated_strings.go.en.json"), filepath.Join(inputFilesPath, "test_interpolated_strings.go.en.json"))
+		Context("input file contains some interpolated strings", func() {
+			BeforeEach(func() {
+				dir, err := os.Getwd()
+				Ω(err).ShouldNot(HaveOccurred())
+				rootPath = filepath.Join(dir, "..", "..")
+
+				outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
+				Ω(err).ShouldNot(HaveOccurred())
+
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
+				inputFilesPath = filepath.Join(fixturesPath, "i18n_strings_filename_option", "input_files")
+				expectedFilesPath = filepath.Join(fixturesPath, "i18n_strings_filename_option", "expected_output")
+
+				CopyFile(filepath.Join(inputFilesPath, "_test_interpolated_strings.go.en.json"), filepath.Join(inputFilesPath, "test_interpolated_strings.go.en.json"))
+
+				session := Runi18n("rewrite-package",
+					"-f", filepath.Join(inputFilesPath, "test_interpolated_strings.go"),
+					"-o", outputDir,
+					"--i18n-strings-filename", filepath.Join(inputFilesPath, "test_interpolated_strings.go.en.json"),
+					"-v",
+				)
+
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			AfterEach(func() {
+				CopyFile(filepath.Join(inputFilesPath, "_test_interpolated_strings.go.en.json"), filepath.Join(inputFilesPath, "test_interpolated_strings.go.en.json"))
+			})
+
+			It("converts interpolated strings to templated and rewrites the input file with T() wrappers around the strings (templated and not) specified in the --i18n-strings-filename flag", func() {
+				expectedOutputFile := filepath.Join(expectedFilesPath, "test_interpolated_strings.go")
+				bytes, err := ioutil.ReadFile(expectedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				expectedOutput := string(bytes)
+
+				generatedOutputFile := filepath.Join(outputDir, "test_interpolated_strings.go")
+				bytes, err = ioutil.ReadFile(generatedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				actualOutput := string(bytes)
+
+				Ω(actualOutput).Should(Equal(expectedOutput))
+			})
+
+			It("updates the i18n strings JSON file with the converted interpolated JSON strings", func() {
+				expectedOutputFile := filepath.Join(expectedFilesPath, "test_interpolated_strings.go.en.json")
+				generatedOutputFile := filepath.Join(inputFilesPath, "test_interpolated_strings.go.en.json")
+				CompareExpectedToGeneratedTraslationJson(expectedOutputFile, generatedOutputFile)
+			})
 		})
 
-		It("converts interpolated strings to templated and rewrites the input file with T() wrappers around the strings (templated and not) specified in the --i18n-strings-filename flag", func() {
-			expectedOutputFile := filepath.Join(expectedFilesPath, "test_interpolated_strings.go")
-			bytes, err := ioutil.ReadFile(expectedOutputFile)
-			Ω(err).ShouldNot(HaveOccurred())
-
-			expectedOutput := string(bytes)
-
-			generatedOutputFile := filepath.Join(outputDir, "test_interpolated_strings.go")
-			bytes, err = ioutil.ReadFile(generatedOutputFile)
-			Ω(err).ShouldNot(HaveOccurred())
-
-			actualOutput := string(bytes)
-
-			Ω(actualOutput).Should(Equal(expectedOutput))
-		})
-
-		It("updates the i18n strings JSON file with the converted interpolated JSON strings", func() {
-			expectedOutputFile := filepath.Join(expectedFilesPath, "test_interpolated_strings.go.en.json")
-			generatedOutputFile := filepath.Join(inputFilesPath, "test_interpolated_strings.go.en.json")
-			CompareExpectedToGeneratedTraslationJson(expectedOutputFile, generatedOutputFile)
-		})
 	})
 })

--- a/integration/rewrite_package/init_code_snippet_filename_test.go
+++ b/integration/rewrite_package/init_code_snippet_filename_test.go
@@ -39,114 +39,229 @@ var _ = Describe("rewrite-package [...] --init-code-snippet-filename some-file",
 		Ω(err).ShouldNot(HaveOccurred())
 	})
 
-	Context("invokes rewrite-package command and uses the default i18n init function", func() {
-		BeforeEach(func() {
-			dir, err := os.Getwd()
-			Ω(err).ShouldNot(HaveOccurred())
-			rootPath = filepath.Join(dir, "..", "..")
+	Context("Using legacy commands", func() {
+		Context("invokes rewrite-package command and uses the default i18n init function", func() {
+			BeforeEach(func() {
+				dir, err := os.Getwd()
+				Ω(err).ShouldNot(HaveOccurred())
+				rootPath = filepath.Join(dir, "..", "..")
 
-			outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
-			Ω(err).ShouldNot(HaveOccurred())
+				outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
+				Ω(err).ShouldNot(HaveOccurred())
 
-			fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
-			inputFilesPath = filepath.Join(fixturesPath, "init_code_snippet_filename", "input_files")
-			expectedFilesPath = filepath.Join(fixturesPath, "init_code_snippet_filename", "expected_output")
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
+				inputFilesPath = filepath.Join(fixturesPath, "init_code_snippet_filename", "input_files")
+				expectedFilesPath = filepath.Join(fixturesPath, "init_code_snippet_filename", "expected_output")
 
-			session := Runi18n("-c",
-				"rewrite-package",
-				"-f", filepath.Join(inputFilesPath, "issue14.go"),
-				"-o", outputDir,
-				"--root-path", rootPath,
-				"-v",
-			)
+				session := Runi18n("-c",
+					"rewrite-package",
+					"-f", filepath.Join(inputFilesPath, "issue14.go"),
+					"-o", outputDir,
+					"--root-path", rootPath,
+					"-v",
+				)
 
-			Ω(session.ExitCode()).Should(Equal(0))
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			It("rewrites the source go file wrapping strings with T() and generates a i18n_init.go using default", func() {
+				expectedOutputFile := filepath.Join(expectedFilesPath, "issue14.go")
+				bytes, err := ioutil.ReadFile(expectedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				expectedOutput := string(bytes)
+
+				generatedOutputFile := filepath.Join(outputDir, "issue14.go")
+				bytes, err = ioutil.ReadFile(generatedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				actualOutput := string(bytes)
+
+				Ω(actualOutput).Should(Equal(expectedOutput))
+
+				expectedOutputFile = filepath.Join(expectedFilesPath, "i18n_init_default.go")
+				bytes, err = ioutil.ReadFile(expectedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				expectedOutput = strings.Trim(string(bytes), "\n")
+
+				generatedOutputFile = filepath.Join(outputDir, "i18n_init.go")
+				bytes, err = ioutil.ReadFile(generatedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				actualOutput = string(bytes)
+
+				Ω(actualOutput).Should(Equal(expectedOutput))
+			})
 		})
 
-		It("rewrites the source go file wrapping strings with T() and generates a i18n_init.go using default", func() {
-			expectedOutputFile := filepath.Join(expectedFilesPath, "issue14.go")
-			bytes, err := ioutil.ReadFile(expectedOutputFile)
-			Ω(err).ShouldNot(HaveOccurred())
+		Context("invokes rewrite-package command and uses the specified --init-code-snippet-filename", func() {
+			BeforeEach(func() {
+				dir, err := os.Getwd()
+				Ω(err).ShouldNot(HaveOccurred())
+				rootPath = filepath.Join(dir, "..", "..")
 
-			expectedOutput := string(bytes)
+				outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
+				Ω(err).ShouldNot(HaveOccurred())
 
-			generatedOutputFile := filepath.Join(outputDir, "issue14.go")
-			bytes, err = ioutil.ReadFile(generatedOutputFile)
-			Ω(err).ShouldNot(HaveOccurred())
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
+				inputFilesPath = filepath.Join(fixturesPath, "init_code_snippet_filename", "input_files")
+				expectedFilesPath = filepath.Join(fixturesPath, "init_code_snippet_filename", "expected_output")
 
-			actualOutput := string(bytes)
+				session := Runi18n("-c",
+					"rewrite-package",
+					"-f", filepath.Join(inputFilesPath, "issue14.go"),
+					"-o", outputDir,
+					"--init-code-snippet-filename", filepath.Join(inputFilesPath, "init_code_snippet.go.template"),
+					"--root-path", rootPath,
+					"-v",
+				)
 
-			Ω(actualOutput).Should(Equal(expectedOutput))
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
 
-			expectedOutputFile = filepath.Join(expectedFilesPath, "i18n_init_default.go")
-			bytes, err = ioutil.ReadFile(expectedOutputFile)
-			Ω(err).ShouldNot(HaveOccurred())
+			It("rewrites the source go file wrapping strings with T() and generates a i18n_init.go using teamplate file", func() {
+				expectedOutputFile := filepath.Join(expectedFilesPath, "issue14.go")
+				bytes, err := ioutil.ReadFile(expectedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
 
-			expectedOutput = strings.Trim(string(bytes), "\n")
+				expectedOutput := string(bytes)
 
-			generatedOutputFile = filepath.Join(outputDir, "i18n_init.go")
-			bytes, err = ioutil.ReadFile(generatedOutputFile)
-			Ω(err).ShouldNot(HaveOccurred())
+				generatedOutputFile := filepath.Join(outputDir, "issue14.go")
+				bytes, err = ioutil.ReadFile(generatedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
 
-			actualOutput = string(bytes)
+				actualOutput := string(bytes)
 
-			Ω(actualOutput).Should(Equal(expectedOutput))
+				Ω(actualOutput).Should(Equal(expectedOutput))
+
+				expectedOutputFile = filepath.Join(expectedFilesPath, "i18n_init_from_template.go")
+				bytes, err = ioutil.ReadFile(expectedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				expectedOutput = string(bytes)
+
+				generatedOutputFile = filepath.Join(outputDir, "i18n_init.go")
+				bytes, err = ioutil.ReadFile(generatedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				actualOutput = string(bytes)
+
+				Ω(actualOutput).Should(Equal(expectedOutput))
+			})
 		})
+
 	})
 
-	Context("invokes rewrite-package command and uses the specified --init-code-snippet-filename", func() {
-		BeforeEach(func() {
-			dir, err := os.Getwd()
-			Ω(err).ShouldNot(HaveOccurred())
-			rootPath = filepath.Join(dir, "..", "..")
+	Context("Using cobra commands", func() {
+		Context("invokes rewrite-package command and uses the default i18n init function", func() {
+			BeforeEach(func() {
+				dir, err := os.Getwd()
+				Ω(err).ShouldNot(HaveOccurred())
+				rootPath = filepath.Join(dir, "..", "..")
 
-			outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
-			Ω(err).ShouldNot(HaveOccurred())
+				outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
+				Ω(err).ShouldNot(HaveOccurred())
 
-			fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
-			inputFilesPath = filepath.Join(fixturesPath, "init_code_snippet_filename", "input_files")
-			expectedFilesPath = filepath.Join(fixturesPath, "init_code_snippet_filename", "expected_output")
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
+				inputFilesPath = filepath.Join(fixturesPath, "init_code_snippet_filename", "input_files")
+				expectedFilesPath = filepath.Join(fixturesPath, "init_code_snippet_filename", "expected_output")
 
-			session := Runi18n("-c",
-				"rewrite-package",
-				"-f", filepath.Join(inputFilesPath, "issue14.go"),
-				"-o", outputDir,
-				"--init-code-snippet-filename", filepath.Join(inputFilesPath, "init_code_snippet.go.template"),
-				"--root-path", rootPath,
-				"-v",
-			)
+				session := Runi18n("rewrite-package",
+					"-f", filepath.Join(inputFilesPath, "issue14.go"),
+					"-o", outputDir,
+					"--root-path", rootPath,
+					"-v",
+				)
 
-			Ω(session.ExitCode()).Should(Equal(0))
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			It("rewrites the source go file wrapping strings with T() and generates a i18n_init.go using default", func() {
+				expectedOutputFile := filepath.Join(expectedFilesPath, "issue14.go")
+				bytes, err := ioutil.ReadFile(expectedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				expectedOutput := string(bytes)
+
+				generatedOutputFile := filepath.Join(outputDir, "issue14.go")
+				bytes, err = ioutil.ReadFile(generatedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				actualOutput := string(bytes)
+
+				Ω(actualOutput).Should(Equal(expectedOutput))
+
+				expectedOutputFile = filepath.Join(expectedFilesPath, "i18n_init_default.go")
+				bytes, err = ioutil.ReadFile(expectedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				expectedOutput = strings.Trim(string(bytes), "\n")
+
+				generatedOutputFile = filepath.Join(outputDir, "i18n_init.go")
+				bytes, err = ioutil.ReadFile(generatedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				actualOutput = string(bytes)
+
+				Ω(actualOutput).Should(Equal(expectedOutput))
+			})
 		})
 
-		It("rewrites the source go file wrapping strings with T() and generates a i18n_init.go using teamplate file", func() {
-			expectedOutputFile := filepath.Join(expectedFilesPath, "issue14.go")
-			bytes, err := ioutil.ReadFile(expectedOutputFile)
-			Ω(err).ShouldNot(HaveOccurred())
+		Context("invokes rewrite-package command and uses the specified --init-code-snippet-filename", func() {
+			BeforeEach(func() {
+				dir, err := os.Getwd()
+				Ω(err).ShouldNot(HaveOccurred())
+				rootPath = filepath.Join(dir, "..", "..")
 
-			expectedOutput := string(bytes)
+				outputDir, err = ioutil.TempDir(rootPath, "i18n4go_integration")
+				Ω(err).ShouldNot(HaveOccurred())
 
-			generatedOutputFile := filepath.Join(outputDir, "issue14.go")
-			bytes, err = ioutil.ReadFile(generatedOutputFile)
-			Ω(err).ShouldNot(HaveOccurred())
+				fixturesPath = filepath.Join("..", "..", "test_fixtures", "rewrite_package")
+				inputFilesPath = filepath.Join(fixturesPath, "init_code_snippet_filename", "input_files")
+				expectedFilesPath = filepath.Join(fixturesPath, "init_code_snippet_filename", "expected_output")
 
-			actualOutput := string(bytes)
+				session := Runi18n("rewrite-package",
+					"-f", filepath.Join(inputFilesPath, "issue14.go"),
+					"-o", outputDir,
+					"--init-code-snippet-filename", filepath.Join(inputFilesPath, "init_code_snippet.go.template"),
+					"--root-path", rootPath,
+					"-v",
+				)
 
-			Ω(actualOutput).Should(Equal(expectedOutput))
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
 
-			expectedOutputFile = filepath.Join(expectedFilesPath, "i18n_init_from_template.go")
-			bytes, err = ioutil.ReadFile(expectedOutputFile)
-			Ω(err).ShouldNot(HaveOccurred())
+			It("rewrites the source go file wrapping strings with T() and generates a i18n_init.go using teamplate file", func() {
+				expectedOutputFile := filepath.Join(expectedFilesPath, "issue14.go")
+				bytes, err := ioutil.ReadFile(expectedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
 
-			expectedOutput = string(bytes)
+				expectedOutput := string(bytes)
 
-			generatedOutputFile = filepath.Join(outputDir, "i18n_init.go")
-			bytes, err = ioutil.ReadFile(generatedOutputFile)
-			Ω(err).ShouldNot(HaveOccurred())
+				generatedOutputFile := filepath.Join(outputDir, "issue14.go")
+				bytes, err = ioutil.ReadFile(generatedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
 
-			actualOutput = string(bytes)
+				actualOutput := string(bytes)
 
-			Ω(actualOutput).Should(Equal(expectedOutput))
+				Ω(actualOutput).Should(Equal(expectedOutput))
+
+				expectedOutputFile = filepath.Join(expectedFilesPath, "i18n_init_from_template.go")
+				bytes, err = ioutil.ReadFile(expectedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				expectedOutput = string(bytes)
+
+				generatedOutputFile = filepath.Join(outputDir, "i18n_init.go")
+				bytes, err = ioutil.ReadFile(generatedOutputFile)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				actualOutput = string(bytes)
+
+				Ω(actualOutput).Should(Equal(expectedOutput))
+			})
 		})
+
 	})
 })

--- a/integration/verify_strings/duplicate_keys_test.go
+++ b/integration/verify_strings/duplicate_keys_test.go
@@ -41,12 +41,24 @@ var _ = Describe("verify-strings -f fileName", func() {
 		inputFilesPath = filepath.Join(fixturesPath, "duplicate_keys", "input_files")
 		expectedFilesPath = filepath.Join(fixturesPath, "duplicate_keys", "expected_output")
 	})
-
-	Context("checks for duplicate keys", func() {
-		It("should error", func() {
-			session := Runi18n("-c", "verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"fr\"", "-o", expectedFilesPath, "--source-language", "en")
-			Ω(session.ExitCode()).Should(Equal(1))
-			Ω(session).Should(gbytes.Say("Duplicated key found: Show quota info"))
+	Context("Using legacy commands", func() {
+		Context("checks for duplicate keys", func() {
+			It("should error", func() {
+				session := Runi18n("-c", "verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"fr\"", "-o", expectedFilesPath, "--source-language", "en")
+				Ω(session.ExitCode()).Should(Equal(1))
+				Ω(session).Should(gbytes.Say("Duplicated key found: Show quota info"))
+			})
 		})
 	})
+
+	Context("Using cobra commands", func() {
+		Context("checks for duplicate keys", func() {
+			It("should error", func() {
+				session := Runi18n("verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"fr\"", "-o", expectedFilesPath, "--source-language", "en")
+				Ω(session.ExitCode()).Should(Equal(1))
+				Ω(session).Should(gbytes.Say("Duplicated key found: Show quota info"))
+			})
+		})
+	})
+
 })

--- a/integration/verify_strings/f_option_test.go
+++ b/integration/verify_strings/f_option_test.go
@@ -35,224 +35,452 @@ var _ = Describe("verify-strings -f fileName --languages \"[lang,?]+\"", func() 
 		expectedFilesPath = filepath.Join(fixturesPath, "f_option", "expected_output")
 	})
 
-	Context("valid input file provided", func() {
-		Context("using --source-language", func() {
-			Context("passes verifications", func() {
-				BeforeEach(func() {
-					session := Runi18n("-c", "verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"fr,zh_CN\"", "-o", expectedFilesPath, "--source-language", "en")
-					Ω(session.ExitCode()).Should(Equal(0))
-				})
-
-				It("with language file with valid keys", func() {
-					_, err := os.Stat(GetFilePath(inputFilesPath, "quota.go.en.json.missing.diff"))
-					Ω(os.IsNotExist(err)).Should(Equal(true))
-
-					_, err = os.Stat(GetFilePath(inputFilesPath, "quota.go.en.json.extra.diff"))
-					Ω(os.IsNotExist(err)).Should(Equal(true))
-				})
-			})
-		})
-
-		Context("not using --source-language", func() {
-			Context("passes verifications", func() {
-				BeforeEach(func() {
-					session := Runi18n("-c", "verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"fr,zh_CN\"", "-o", expectedFilesPath)
-					Ω(session.ExitCode()).Should(Equal(0))
-				})
-
-				It("with language file with valid keys", func() {
-					_, err := os.Stat(GetFilePath(inputFilesPath, "quota.go.fr.json.missing.diff.json"))
-					Ω(os.IsNotExist(err)).Should(Equal(true))
-
-					_, err = os.Stat(GetFilePath(inputFilesPath, "quota.go.fr.json.missing.diff.json"))
-					Ω(os.IsNotExist(err)).Should(Equal(true))
-
-					_, err = os.Stat(GetFilePath(inputFilesPath, "quota.go.zh_CN.json.extra.diff.json"))
-					Ω(os.IsNotExist(err)).Should(Equal(true))
-
-					_, err = os.Stat(GetFilePath(inputFilesPath, "quota.go.zh_CN.json.extra.diff.json"))
-					Ω(os.IsNotExist(err)).Should(Equal(true))
-				})
-			})
-		})
-
-		Context("fails verification", func() {
-			Context("with one language file", func() {
-				Context("with missing keys", func() {
+	Context("Using legacy commands", func() {
+		Context("valid input file provided", func() {
+			Context("using --source-language", func() {
+				Context("passes verifications", func() {
 					BeforeEach(func() {
-						session := Runi18n("-c", "verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"de\"", "-o", expectedFilesPath, "--source-language", "en")
+						session := Runi18n("-c", "verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"fr,zh_CN\"", "-o", expectedFilesPath, "--source-language", "en")
+						Ω(session.ExitCode()).Should(Equal(0))
+					})
+
+					It("with language file with valid keys", func() {
+						_, err := os.Stat(GetFilePath(inputFilesPath, "quota.go.en.json.missing.diff"))
+						Ω(os.IsNotExist(err)).Should(Equal(true))
+
+						_, err = os.Stat(GetFilePath(inputFilesPath, "quota.go.en.json.extra.diff"))
+						Ω(os.IsNotExist(err)).Should(Equal(true))
+					})
+				})
+			})
+
+			Context("not using --source-language", func() {
+				Context("passes verifications", func() {
+					BeforeEach(func() {
+						session := Runi18n("-c", "verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"fr,zh_CN\"", "-o", expectedFilesPath)
+						Ω(session.ExitCode()).Should(Equal(0))
+					})
+
+					It("with language file with valid keys", func() {
+						_, err := os.Stat(GetFilePath(inputFilesPath, "quota.go.fr.json.missing.diff.json"))
+						Ω(os.IsNotExist(err)).Should(Equal(true))
+
+						_, err = os.Stat(GetFilePath(inputFilesPath, "quota.go.fr.json.missing.diff.json"))
+						Ω(os.IsNotExist(err)).Should(Equal(true))
+
+						_, err = os.Stat(GetFilePath(inputFilesPath, "quota.go.zh_CN.json.extra.diff.json"))
+						Ω(os.IsNotExist(err)).Should(Equal(true))
+
+						_, err = os.Stat(GetFilePath(inputFilesPath, "quota.go.zh_CN.json.extra.diff.json"))
+						Ω(os.IsNotExist(err)).Should(Equal(true))
+					})
+				})
+			})
+
+			Context("fails verification", func() {
+				Context("with one language file", func() {
+					Context("with missing keys", func() {
+						BeforeEach(func() {
+							session := Runi18n("-c", "verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"de\"", "-o", expectedFilesPath, "--source-language", "en")
+							Ω(session.ExitCode()).Should(Equal(1))
+						})
+
+						AfterEach(func() {
+							RemoveAllFiles(
+								GetFilePath(expectedFilesPath, "quota.go.de.json.missing.diff.json"),
+							)
+						})
+
+						It("generates missing diff file", func() {
+							fileInfo, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.de.json.missing.diff.json"))
+							Ω(err).Should(BeNil())
+							Ω(fileInfo.Name()).Should(Equal("quota.go.de.json.missing.diff.json"))
+						})
+					})
+
+					Context("with missing and extra keys", func() {
+						BeforeEach(func() {
+							session := Runi18n("-c", "verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"af\"", "-o", expectedFilesPath, "--source-language", "en")
+							Ω(session.ExitCode()).Should(Equal(1))
+						})
+
+						AfterEach(func() {
+							RemoveAllFiles(
+								GetFilePath(expectedFilesPath, "quota.go.af.json.missing.diff.json"),
+								GetFilePath(expectedFilesPath, "quota.go.af.json.extra.diff.json"),
+							)
+						})
+
+						It("generates missing and extra diff file", func() {
+							fileInfo, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.af.json.missing.diff.json"))
+							Ω(err).Should(BeNil())
+							Ω(fileInfo.Name()).Should(Equal("quota.go.af.json.missing.diff.json"))
+
+							fileInfo, err = os.Stat(GetFilePath(expectedFilesPath, "quota.go.af.json.extra.diff.json"))
+							Ω(err).Should(BeNil())
+							Ω(fileInfo.Name()).Should(Equal("quota.go.af.json.extra.diff.json"))
+						})
+					})
+
+					Context("with templated keys whose translation does not contain same arguments", func() {
+						BeforeEach(func() {
+							session := Runi18n("-c", "verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"es\"", "-o", expectedFilesPath, "--source-language", "en")
+							Ω(session.ExitCode()).Should(Equal(1))
+						})
+
+						AfterEach(func() {
+							RemoveAllFiles(
+								GetFilePath(expectedFilesPath, "quota.go.es.json.invalid.diff.json"),
+							)
+						})
+
+						It("generates invalid diff file", func() {
+							fileInfo, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.es.json.invalid.diff.json"))
+							Ω(err).Should(BeNil())
+							Ω(fileInfo.Name()).Should(Equal("quota.go.es.json.invalid.diff.json"))
+						})
+					})
+				})
+
+				Context("with multiple language files", func() {
+					BeforeEach(func() {
+						session := Runi18n("-c", "verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"de,it\"", "-o", expectedFilesPath, "--source-language", "en")
 						Ω(session.ExitCode()).Should(Equal(1))
 					})
 
 					AfterEach(func() {
 						RemoveAllFiles(
 							GetFilePath(expectedFilesPath, "quota.go.de.json.missing.diff.json"),
+							GetFilePath(expectedFilesPath, "quota.go.it.json.missing.diff.json"),
 						)
 					})
 
-					It("generates missing diff file", func() {
+					It("with invalid keys", func() {
 						fileInfo, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.de.json.missing.diff.json"))
 						Ω(err).Should(BeNil())
 						Ω(fileInfo.Name()).Should(Equal("quota.go.de.json.missing.diff.json"))
-					})
-				})
 
-				Context("with missing and extra keys", func() {
-					BeforeEach(func() {
-						session := Runi18n("-c", "verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"af\"", "-o", expectedFilesPath, "--source-language", "en")
-						Ω(session.ExitCode()).Should(Equal(1))
-					})
-
-					AfterEach(func() {
-						RemoveAllFiles(
-							GetFilePath(expectedFilesPath, "quota.go.af.json.missing.diff.json"),
-							GetFilePath(expectedFilesPath, "quota.go.af.json.extra.diff.json"),
-						)
-					})
-
-					It("generates missing and extra diff file", func() {
-						fileInfo, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.af.json.missing.diff.json"))
+						fileInfo, err = os.Stat(GetFilePath(expectedFilesPath, "quota.go.it.json.missing.diff.json"))
 						Ω(err).Should(BeNil())
-						Ω(fileInfo.Name()).Should(Equal("quota.go.af.json.missing.diff.json"))
-
-						fileInfo, err = os.Stat(GetFilePath(expectedFilesPath, "quota.go.af.json.extra.diff.json"))
-						Ω(err).Should(BeNil())
-						Ω(fileInfo.Name()).Should(Equal("quota.go.af.json.extra.diff.json"))
-					})
-				})
-
-				Context("with templated keys whose translation does not contain same arguments", func() {
-					BeforeEach(func() {
-						session := Runi18n("-c", "verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"es\"", "-o", expectedFilesPath, "--source-language", "en")
-						Ω(session.ExitCode()).Should(Equal(1))
-					})
-
-					AfterEach(func() {
-						RemoveAllFiles(
-							GetFilePath(expectedFilesPath, "quota.go.es.json.invalid.diff.json"),
-						)
-					})
-
-					It("generates invalid diff file", func() {
-						fileInfo, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.es.json.invalid.diff.json"))
-						Ω(err).Should(BeNil())
-						Ω(fileInfo.Name()).Should(Equal("quota.go.es.json.invalid.diff.json"))
+						Ω(fileInfo.Name()).Should(Equal("quota.go.it.json.missing.diff.json"))
 					})
 				})
 			})
 
-			Context("with multiple language files", func() {
+			Context("with language file", func() {
 				BeforeEach(func() {
-					session := Runi18n("-c", "verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"de,it\"", "-o", expectedFilesPath, "--source-language", "en")
+					session := Runi18n("-c", "verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"ja\"", "-o", expectedFilesPath)
 					Ω(session.ExitCode()).Should(Equal(1))
 				})
 
 				AfterEach(func() {
 					RemoveAllFiles(
-						GetFilePath(expectedFilesPath, "quota.go.de.json.missing.diff.json"),
-						GetFilePath(expectedFilesPath, "quota.go.it.json.missing.diff.json"),
+						GetFilePath(expectedFilesPath, "quota.go.ja.json.extra.diff.json"),
 					)
 				})
 
-				It("with invalid keys", func() {
-					fileInfo, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.de.json.missing.diff.json"))
+				It("with additional keys", func() {
+					fileInfo, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.ja.json.extra.diff.json"))
 					Ω(err).Should(BeNil())
-					Ω(fileInfo.Name()).Should(Equal("quota.go.de.json.missing.diff.json"))
+					Ω(fileInfo.Name()).Should(Equal("quota.go.ja.json.extra.diff.json"))
+				})
+			})
 
-					fileInfo, err = os.Stat(GetFilePath(expectedFilesPath, "quota.go.it.json.missing.diff.json"))
+			Context("with multiple language file", func() {
+				BeforeEach(func() {
+					session := Runi18n("-c", "verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"ja,cs\"", "-o", expectedFilesPath)
+					Ω(session.ExitCode()).Should(Equal(1))
+				})
+
+				AfterEach(func() {
+					RemoveAllFiles(
+						GetFilePath(expectedFilesPath, "quota.go.ja.json.extra.diff.json"),
+						GetFilePath(expectedFilesPath, "quota.go.cs.json.extra.diff.json"),
+					)
+				})
+
+				It("with additional keys", func() {
+					fileInfo, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.ja.json.extra.diff.json"))
 					Ω(err).Should(BeNil())
-					Ω(fileInfo.Name()).Should(Equal("quota.go.it.json.missing.diff.json"))
+					Ω(fileInfo.Name()).Should(Equal("quota.go.ja.json.extra.diff.json"))
+
+					fileInfo, err = os.Stat(GetFilePath(expectedFilesPath, "quota.go.cs.json.extra.diff.json"))
+					Ω(err).Should(BeNil())
+					Ω(fileInfo.Name()).Should(Equal("quota.go.cs.json.extra.diff.json"))
+				})
+			})
+
+			Context("when missing a language file", func() {
+				BeforeEach(func() {
+					session := Runi18n("-c", "verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"ja,ht\"", "-o", expectedFilesPath)
+					Ω(session.ExitCode()).Should(Equal(1))
+				})
+
+				AfterEach(func() {
+					RemoveAllFiles(
+						GetFilePath(expectedFilesPath, "quota.go.ja.json.extra.diff.json"),
+					)
+				})
+
+				It("with additional keys", func() {
+					fileInfo, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.ja.json.extra.diff.json"))
+					Ω(err).Should(BeNil())
+					Ω(fileInfo.Name()).Should(Equal("quota.go.ja.json.extra.diff.json"))
 				})
 			})
 		})
 
-		Context("with language file", func() {
-			BeforeEach(func() {
-				session := Runi18n("-c", "verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"ja\"", "-o", expectedFilesPath)
-				Ω(session.ExitCode()).Should(Equal(1))
+		Context("invalid input file provided", func() {
+			Context("does not exist", func() {
+				BeforeEach(func() {
+					session := Runi18n("-c", "verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.ht.json"), "--languages", "\"fr\"", "-o", expectedFilesPath, "--source-language", "en")
+					Ω(session.ExitCode()).Should(Equal(1))
+				})
+
+				It("fails verification", func() {
+					_, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.ht.json"))
+					Ω(os.IsNotExist(err)).Should(Equal(true))
+				})
 			})
 
-			AfterEach(func() {
-				RemoveAllFiles(
-					GetFilePath(expectedFilesPath, "quota.go.ja.json.extra.diff.json"),
-				)
-			})
+			Context("does not have any keys", func() {
+				BeforeEach(func() {
+					session := Runi18n("-c", "verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.vi.json"), "--languages", "\"fr\"", "-o", expectedFilesPath, "--source-language", "en")
+					Ω(session.ExitCode()).Should(Equal(1))
+				})
 
-			It("with additional keys", func() {
-				fileInfo, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.ja.json.extra.diff.json"))
-				Ω(err).Should(BeNil())
-				Ω(fileInfo.Name()).Should(Equal("quota.go.ja.json.extra.diff.json"))
-			})
-		})
-
-		Context("with multiple language file", func() {
-			BeforeEach(func() {
-				session := Runi18n("-c", "verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"ja,cs\"", "-o", expectedFilesPath)
-				Ω(session.ExitCode()).Should(Equal(1))
-			})
-
-			AfterEach(func() {
-				RemoveAllFiles(
-					GetFilePath(expectedFilesPath, "quota.go.ja.json.extra.diff.json"),
-					GetFilePath(expectedFilesPath, "quota.go.cs.json.extra.diff.json"),
-				)
-			})
-
-			It("with additional keys", func() {
-				fileInfo, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.ja.json.extra.diff.json"))
-				Ω(err).Should(BeNil())
-				Ω(fileInfo.Name()).Should(Equal("quota.go.ja.json.extra.diff.json"))
-
-				fileInfo, err = os.Stat(GetFilePath(expectedFilesPath, "quota.go.cs.json.extra.diff.json"))
-				Ω(err).Should(BeNil())
-				Ω(fileInfo.Name()).Should(Equal("quota.go.cs.json.extra.diff.json"))
+				It("fails verification", func() {
+					fileInfo, err := os.Stat(GetFilePath(inputFilesPath, "quota.go.vi.json"))
+					Ω(err).Should(BeNil())
+					Ω(fileInfo.Name()).Should(Equal("quota.go.vi.json"))
+				})
 			})
 		})
 
-		Context("when missing a language file", func() {
-			BeforeEach(func() {
-				session := Runi18n("-c", "verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"ja,ht\"", "-o", expectedFilesPath)
-				Ω(session.ExitCode()).Should(Equal(1))
-			})
-
-			AfterEach(func() {
-				RemoveAllFiles(
-					GetFilePath(expectedFilesPath, "quota.go.ja.json.extra.diff.json"),
-				)
-			})
-
-			It("with additional keys", func() {
-				fileInfo, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.ja.json.extra.diff.json"))
-				Ω(err).Should(BeNil())
-				Ω(fileInfo.Name()).Should(Equal("quota.go.ja.json.extra.diff.json"))
-			})
-		})
 	})
 
-	Context("invalid input file provided", func() {
-		Context("does not exist", func() {
-			BeforeEach(func() {
-				session := Runi18n("-c", "verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.ht.json"), "--languages", "\"fr\"", "-o", expectedFilesPath, "--source-language", "en")
-				Ω(session.ExitCode()).Should(Equal(1))
+	Context("Using cobra commands", func() {
+		Context("valid input file provided", func() {
+			Context("using --source-language", func() {
+				Context("passes verifications", func() {
+					BeforeEach(func() {
+						session := Runi18n("verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"fr,zh_CN\"", "-o", expectedFilesPath, "--source-language", "en")
+						Ω(session.ExitCode()).Should(Equal(0))
+					})
+
+					It("with language file with valid keys", func() {
+						_, err := os.Stat(GetFilePath(inputFilesPath, "quota.go.en.json.missing.diff"))
+						Ω(os.IsNotExist(err)).Should(Equal(true))
+
+						_, err = os.Stat(GetFilePath(inputFilesPath, "quota.go.en.json.extra.diff"))
+						Ω(os.IsNotExist(err)).Should(Equal(true))
+					})
+				})
 			})
 
-			It("fails verification", func() {
-				_, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.ht.json"))
-				Ω(os.IsNotExist(err)).Should(Equal(true))
+			Context("not using --source-language", func() {
+				Context("passes verifications", func() {
+					BeforeEach(func() {
+						session := Runi18n("verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"fr,zh_CN\"", "-o", expectedFilesPath)
+						Ω(session.ExitCode()).Should(Equal(0))
+					})
+
+					It("with language file with valid keys", func() {
+						_, err := os.Stat(GetFilePath(inputFilesPath, "quota.go.fr.json.missing.diff.json"))
+						Ω(os.IsNotExist(err)).Should(Equal(true))
+
+						_, err = os.Stat(GetFilePath(inputFilesPath, "quota.go.fr.json.missing.diff.json"))
+						Ω(os.IsNotExist(err)).Should(Equal(true))
+
+						_, err = os.Stat(GetFilePath(inputFilesPath, "quota.go.zh_CN.json.extra.diff.json"))
+						Ω(os.IsNotExist(err)).Should(Equal(true))
+
+						_, err = os.Stat(GetFilePath(inputFilesPath, "quota.go.zh_CN.json.extra.diff.json"))
+						Ω(os.IsNotExist(err)).Should(Equal(true))
+					})
+				})
+			})
+
+			Context("fails verification", func() {
+				Context("with one language file", func() {
+					Context("with missing keys", func() {
+						BeforeEach(func() {
+							session := Runi18n("verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"de\"", "-o", expectedFilesPath, "--source-language", "en")
+							Ω(session.ExitCode()).Should(Equal(1))
+						})
+
+						AfterEach(func() {
+							RemoveAllFiles(
+								GetFilePath(expectedFilesPath, "quota.go.de.json.missing.diff.json"),
+							)
+						})
+
+						It("generates missing diff file", func() {
+							fileInfo, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.de.json.missing.diff.json"))
+							Ω(err).Should(BeNil())
+							Ω(fileInfo.Name()).Should(Equal("quota.go.de.json.missing.diff.json"))
+						})
+					})
+
+					Context("with missing and extra keys", func() {
+						BeforeEach(func() {
+							session := Runi18n("verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"af\"", "-o", expectedFilesPath, "--source-language", "en")
+							Ω(session.ExitCode()).Should(Equal(1))
+						})
+
+						AfterEach(func() {
+							RemoveAllFiles(
+								GetFilePath(expectedFilesPath, "quota.go.af.json.missing.diff.json"),
+								GetFilePath(expectedFilesPath, "quota.go.af.json.extra.diff.json"),
+							)
+						})
+
+						It("generates missing and extra diff file", func() {
+							fileInfo, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.af.json.missing.diff.json"))
+							Ω(err).Should(BeNil())
+							Ω(fileInfo.Name()).Should(Equal("quota.go.af.json.missing.diff.json"))
+
+							fileInfo, err = os.Stat(GetFilePath(expectedFilesPath, "quota.go.af.json.extra.diff.json"))
+							Ω(err).Should(BeNil())
+							Ω(fileInfo.Name()).Should(Equal("quota.go.af.json.extra.diff.json"))
+						})
+					})
+
+					Context("with templated keys whose translation does not contain same arguments", func() {
+						BeforeEach(func() {
+							session := Runi18n("verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"es\"", "-o", expectedFilesPath, "--source-language", "en")
+							Ω(session.ExitCode()).Should(Equal(1))
+						})
+
+						AfterEach(func() {
+							RemoveAllFiles(
+								GetFilePath(expectedFilesPath, "quota.go.es.json.invalid.diff.json"),
+							)
+						})
+
+						It("generates invalid diff file", func() {
+							fileInfo, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.es.json.invalid.diff.json"))
+							Ω(err).Should(BeNil())
+							Ω(fileInfo.Name()).Should(Equal("quota.go.es.json.invalid.diff.json"))
+						})
+					})
+				})
+
+				Context("with multiple language files", func() {
+					BeforeEach(func() {
+						session := Runi18n("verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"de,it\"", "-o", expectedFilesPath, "--source-language", "en")
+						Ω(session.ExitCode()).Should(Equal(1))
+					})
+
+					AfterEach(func() {
+						RemoveAllFiles(
+							GetFilePath(expectedFilesPath, "quota.go.de.json.missing.diff.json"),
+							GetFilePath(expectedFilesPath, "quota.go.it.json.missing.diff.json"),
+						)
+					})
+
+					It("with invalid keys", func() {
+						fileInfo, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.de.json.missing.diff.json"))
+						Ω(err).Should(BeNil())
+						Ω(fileInfo.Name()).Should(Equal("quota.go.de.json.missing.diff.json"))
+
+						fileInfo, err = os.Stat(GetFilePath(expectedFilesPath, "quota.go.it.json.missing.diff.json"))
+						Ω(err).Should(BeNil())
+						Ω(fileInfo.Name()).Should(Equal("quota.go.it.json.missing.diff.json"))
+					})
+				})
+			})
+
+			Context("with language file", func() {
+				BeforeEach(func() {
+					session := Runi18n("verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"ja\"", "-o", expectedFilesPath)
+					Ω(session.ExitCode()).Should(Equal(1))
+				})
+
+				AfterEach(func() {
+					RemoveAllFiles(
+						GetFilePath(expectedFilesPath, "quota.go.ja.json.extra.diff.json"),
+					)
+				})
+
+				It("with additional keys", func() {
+					fileInfo, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.ja.json.extra.diff.json"))
+					Ω(err).Should(BeNil())
+					Ω(fileInfo.Name()).Should(Equal("quota.go.ja.json.extra.diff.json"))
+				})
+			})
+
+			Context("with multiple language file", func() {
+				BeforeEach(func() {
+					session := Runi18n("verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"ja,cs\"", "-o", expectedFilesPath)
+					Ω(session.ExitCode()).Should(Equal(1))
+				})
+
+				AfterEach(func() {
+					RemoveAllFiles(
+						GetFilePath(expectedFilesPath, "quota.go.ja.json.extra.diff.json"),
+						GetFilePath(expectedFilesPath, "quota.go.cs.json.extra.diff.json"),
+					)
+				})
+
+				It("with additional keys", func() {
+					fileInfo, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.ja.json.extra.diff.json"))
+					Ω(err).Should(BeNil())
+					Ω(fileInfo.Name()).Should(Equal("quota.go.ja.json.extra.diff.json"))
+
+					fileInfo, err = os.Stat(GetFilePath(expectedFilesPath, "quota.go.cs.json.extra.diff.json"))
+					Ω(err).Should(BeNil())
+					Ω(fileInfo.Name()).Should(Equal("quota.go.cs.json.extra.diff.json"))
+				})
+			})
+
+			Context("when missing a language file", func() {
+				BeforeEach(func() {
+					session := Runi18n("verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.en.json"), "--languages", "\"ja,ht\"", "-o", expectedFilesPath)
+					Ω(session.ExitCode()).Should(Equal(1))
+				})
+
+				AfterEach(func() {
+					RemoveAllFiles(
+						GetFilePath(expectedFilesPath, "quota.go.ja.json.extra.diff.json"),
+					)
+				})
+
+				It("with additional keys", func() {
+					fileInfo, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.ja.json.extra.diff.json"))
+					Ω(err).Should(BeNil())
+					Ω(fileInfo.Name()).Should(Equal("quota.go.ja.json.extra.diff.json"))
+				})
 			})
 		})
 
-		Context("does not have any keys", func() {
-			BeforeEach(func() {
-				session := Runi18n("-c", "verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.vi.json"), "--languages", "\"fr\"", "-o", expectedFilesPath, "--source-language", "en")
-				Ω(session.ExitCode()).Should(Equal(1))
+		Context("invalid input file provided", func() {
+			Context("does not exist", func() {
+				BeforeEach(func() {
+					session := Runi18n("verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.ht.json"), "--languages", "\"fr\"", "-o", expectedFilesPath, "--source-language", "en")
+					Ω(session.ExitCode()).Should(Equal(1))
+				})
+
+				It("fails verification", func() {
+					_, err := os.Stat(GetFilePath(expectedFilesPath, "quota.go.ht.json"))
+					Ω(os.IsNotExist(err)).Should(Equal(true))
+				})
 			})
 
-			It("fails verification", func() {
-				fileInfo, err := os.Stat(GetFilePath(inputFilesPath, "quota.go.vi.json"))
-				Ω(err).Should(BeNil())
-				Ω(fileInfo.Name()).Should(Equal("quota.go.vi.json"))
+			Context("does not have any keys", func() {
+				BeforeEach(func() {
+					session := Runi18n("-c", "verify-strings", "-v", "-f", filepath.Join(inputFilesPath, "quota.go.vi.json"), "--languages", "\"fr\"", "-o", expectedFilesPath, "--source-language", "en")
+					Ω(session.ExitCode()).Should(Equal(1))
+				})
+
+				It("fails verification", func() {
+					fileInfo, err := os.Stat(GetFilePath(inputFilesPath, "quota.go.vi.json"))
+					Ω(err).Should(BeNil())
+					Ω(fileInfo.Name()).Should(Equal("quota.go.vi.json"))
+				})
 			})
 		})
+
 	})
+
 })


### PR DESCRIPTION
# Context

The purpose of this PR is keep the Cobra commands consistent with the existing behavior using the `-c` legacy option

ref: https://github.com/maximilien/i18n4go/issues/65