### PR TITLE
feat: Added cobra implementation for merge-strings and show-missing-strings

### DIFF
--- a/cmds/merge_string.go
+++ b/cmds/merge_string.go
@@ -36,9 +36,9 @@ type mergeStrings struct {
 	Directory      string
 }
 
-func NewMergeStrings(options common.Options) *mergeStrings {
+func NewMergeStrings(options *common.Options) *mergeStrings {
 	return &mergeStrings{
-		options:         options,
+		options:         *options,
 		I18nStringInfos: []common.I18nStringInfo{},
 		Recurse:         options.RecurseFlag,
 		SourceLanguage:  options.SourceLanguageFlag,
@@ -46,8 +46,8 @@ func NewMergeStrings(options common.Options) *mergeStrings {
 	}
 }
 
-// NewMergeStringsCommand implements 'i18n merge-strings' command
-func NewMergeStringsCommand(p *I18NParams, options common.Options) *cobra.Command {
+// NewMergeStringsCommand implements 'i18n4go merge-strings' command
+func NewMergeStringsCommand(options *common.Options) *cobra.Command {
 	mergeStringsCmd := &cobra.Command{
 		Use:   "merge-strings",
 		Short: "Merge translation strings",
@@ -55,8 +55,10 @@ func NewMergeStringsCommand(p *I18NParams, options common.Options) *cobra.Comman
 			return NewMergeStrings(options).Run()
 		},
 	}
+	mergeStringsCmd.Flags().BoolVarP(&options.RecurseFlag, "recursive", "r", false, "recursively extract strings from all files in the same directory as filename or dirName")
+	mergeStringsCmd.Flags().StringVarP(&options.SourceLanguageFlag, "source-language", "s", "en", "the source language of the file, typically also part of the file name, e.g., \"en_US\"")
 
-	// TODO: setup options and params for Cobra command here using common.Options
+	mergeStringsCmd.Flags().StringVarP(&options.DirnameFlag, "directory", "d", "", "the dir name for which all .go files will have their strings extracted")
 
 	return mergeStringsCmd
 }

--- a/cmds/show_missing_strings.go
+++ b/cmds/show_missing_strings.go
@@ -40,9 +40,9 @@ type showMissingStrings struct {
 	Directory           string
 }
 
-func NewShowMissingStrings(options common.Options) *showMissingStrings {
+func NewShowMissingStrings(options *common.Options) *showMissingStrings {
 	return &showMissingStrings{
-		options:             options,
+		options:             *options,
 		Directory:           options.DirnameFlag,
 		I18nStringsFilename: options.I18nStringsFilenameFlag,
 		TranslatedStrings:   []string{},
@@ -50,7 +50,7 @@ func NewShowMissingStrings(options common.Options) *showMissingStrings {
 }
 
 // NewShowMissingStringsCommand implements 'i18n show-missing-strings' command
-func NewShowMissingStringsCommand(p *I18NParams, options common.Options) *cobra.Command {
+func NewShowMissingStringsCommand(options *common.Options) *cobra.Command {
 	showMissingStringsCmd := &cobra.Command{
 		Use:   "show-missing-strings",
 		Short: "Shows missing strings in translations",
@@ -58,6 +58,9 @@ func NewShowMissingStringsCommand(p *I18NParams, options common.Options) *cobra.
 			return NewShowMissingStrings(options).Run()
 		},
 	}
+
+	showMissingStringsCmd.Flags().StringVarP(&options.DirnameFlag, "directory", "d", "", "the directory containing the go files to validate")
+	showMissingStringsCmd.Flags().StringVar(&options.I18nStringsFilenameFlag, "i18n-strings-filename", "", "a JSON file with the strings that should be i18n enabled, typically the output of -extract-strings command")
 
 	// TODO: setup options and params for Cobra command here using common.Options
 

--- a/i18n4go/i18n4go.go
+++ b/i18n4go/i18n4go.go
@@ -76,6 +76,7 @@ func rootCobraCmd(opts common.Options) {
 	cmd.AddCommand(cmds.NewRewritePackageCommand(&opts))
 	cmd.AddCommand(cmds.NewVerifyStringsCommand(&opts))
 	cmd.AddCommand(cmds.NewFixupCommand(&opts))
+	cmd.AddCommand(cmds.NewMergeStringsCommand(&opts))
 
 	if err := cmd.Execute(); err != nil {
 		fmt.Println(err.Error())
@@ -171,7 +172,7 @@ func mergeStringsCmd() {
 		return
 	}
 
-	mergeStrings := cmds.NewMergeStrings(options)
+	mergeStrings := cmds.NewMergeStrings(&options)
 
 	startTime := time.Now()
 

--- a/i18n4go/i18n4go.go
+++ b/i18n4go/i18n4go.go
@@ -77,6 +77,7 @@ func rootCobraCmd(opts common.Options) {
 	cmd.AddCommand(cmds.NewVerifyStringsCommand(&opts))
 	cmd.AddCommand(cmds.NewFixupCommand(&opts))
 	cmd.AddCommand(cmds.NewMergeStringsCommand(&opts))
+	cmd.AddCommand(cmds.NewShowMissingStringsCommand(&opts))
 
 	if err := cmd.Execute(); err != nil {
 		fmt.Println(err.Error())
@@ -192,7 +193,7 @@ func showMissingStringsCmd() {
 		return
 	}
 
-	showMissingStrings := cmds.NewShowMissingStrings(options)
+	showMissingStrings := cmds.NewShowMissingStrings(&options)
 
 	startTime := time.Now()
 

--- a/integration/merge_strings/d_option_test.go
+++ b/integration/merge_strings/d_option_test.go
@@ -40,67 +40,136 @@ var _ = Describe("merge-strings -d dirName", func() {
 		expectedFilesPath = filepath.Join(fixturesPath, "d_option", "expected_output")
 	})
 
-	Context("can combine multiple language files", func() {
-		Context("merging en files in input_files path", func() {
-			BeforeEach(func() {
-				session := Runi18n("-c", "merge-strings", "-v", "-d", filepath.Join(inputFilesPath), "--source-language", "en")
-				Ω(session.ExitCode()).Should(Equal(0))
+	Context("Using legacy commands", func() {
+		Context("can combine multiple language files", func() {
+			Context("merging en files in input_files path", func() {
+				BeforeEach(func() {
+					session := Runi18n("-c", "merge-strings", "-v", "-d", filepath.Join(inputFilesPath), "--source-language", "en")
+					Ω(session.ExitCode()).Should(Equal(0))
+				})
+
+				AfterEach(func() {
+					RemoveAllFiles(
+						GetFilePath(inputFilesPath, "en.all.json"),
+					)
+				})
+
+				It("creates an en.all.json that contains translations from both files", func() {
+					CompareExpectedToGeneratedTraslationJson(
+						GetFilePath(expectedFilesPath, "en.all.json"),
+						GetFilePath(inputFilesPath, "en.all.json"),
+					)
+				})
+
+				It("creates an en.all.json for which the translation strings order are stable", func() {
+					expectedFilePath := GetFilePath(expectedFilesPath, "en.all.json")
+					actualFilePath := GetFilePath(inputFilesPath, "en.all.json")
+
+					expectedBytes, err := ioutil.ReadFile(expectedFilePath)
+					Ω(err).Should(BeNil())
+					Ω(expectedBytes).ShouldNot(BeNil())
+
+					actualBytes, err := ioutil.ReadFile(actualFilePath)
+					Ω(err).Should(BeNil())
+					Ω(actualBytes).ShouldNot(BeNil())
+
+					Ω(string(expectedBytes)).Should(Equal(string(actualBytes)))
+				})
 			})
 
-			AfterEach(func() {
-				RemoveAllFiles(
-					GetFilePath(inputFilesPath, "en.all.json"),
-				)
-			})
+			Context("merging en files in input_files/reordered path", func() {
+				BeforeEach(func() {
+					session := Runi18n("-c", "merge-strings", "-v", "-d", filepath.Join(inputFilesPath, "reordered"), "--source-language", "en")
+					Ω(session.ExitCode()).Should(Equal(0))
+				})
 
-			It("creates an en.all.json that contains translations from both files", func() {
-				CompareExpectedToGeneratedTraslationJson(
-					GetFilePath(expectedFilesPath, "en.all.json"),
-					GetFilePath(inputFilesPath, "en.all.json"),
-				)
-			})
+				AfterEach(func() {
+					RemoveAllFiles(
+						GetFilePath(filepath.Join(inputFilesPath, "reordered"), "en.all.json"),
+					)
+				})
 
-			It("creates an en.all.json for which the translation strings order are stable", func() {
-				expectedFilePath := GetFilePath(expectedFilesPath, "en.all.json")
-				actualFilePath := GetFilePath(inputFilesPath, "en.all.json")
+				It("creates an en.all.json keeping the stable order", func() {
+					expectedFilePath := GetFilePath(expectedFilesPath, "en.all.json")
+					actualFilePath := GetFilePath(filepath.Join(inputFilesPath, "reordered"), "en.all.json")
 
-				expectedBytes, err := ioutil.ReadFile(expectedFilePath)
-				Ω(err).Should(BeNil())
-				Ω(expectedBytes).ShouldNot(BeNil())
+					expectedBytes, err := ioutil.ReadFile(expectedFilePath)
+					Ω(err).Should(BeNil())
+					Ω(expectedBytes).ShouldNot(BeNil())
 
-				actualBytes, err := ioutil.ReadFile(actualFilePath)
-				Ω(err).Should(BeNil())
-				Ω(actualBytes).ShouldNot(BeNil())
+					actualBytes, err := ioutil.ReadFile(actualFilePath)
+					Ω(err).Should(BeNil())
+					Ω(actualBytes).ShouldNot(BeNil())
 
-				Ω(string(expectedBytes)).Should(Equal(string(actualBytes)))
+					Ω(string(expectedBytes)).Should(Equal(string(actualBytes)))
+				})
 			})
 		})
+	})
 
-		Context("merging en files in input_files/reordered path", func() {
-			BeforeEach(func() {
-				session := Runi18n("-c", "merge-strings", "-v", "-d", filepath.Join(inputFilesPath, "reordered"), "--source-language", "en")
-				Ω(session.ExitCode()).Should(Equal(0))
+	Context("Using cobra commands", func() {
+		Context("can combine multiple language files", func() {
+			Context("merging en files in input_files path", func() {
+				BeforeEach(func() {
+					session := Runi18n("merge-strings", "-v", "-d", filepath.Join(inputFilesPath), "--source-language", "en")
+					Ω(session.ExitCode()).Should(Equal(0))
+				})
+
+				AfterEach(func() {
+					RemoveAllFiles(
+						GetFilePath(inputFilesPath, "en.all.json"),
+					)
+				})
+
+				It("creates an en.all.json that contains translations from both files", func() {
+					CompareExpectedToGeneratedTraslationJson(
+						GetFilePath(expectedFilesPath, "en.all.json"),
+						GetFilePath(inputFilesPath, "en.all.json"),
+					)
+				})
+
+				It("creates an en.all.json for which the translation strings order are stable", func() {
+					expectedFilePath := GetFilePath(expectedFilesPath, "en.all.json")
+					actualFilePath := GetFilePath(inputFilesPath, "en.all.json")
+
+					expectedBytes, err := ioutil.ReadFile(expectedFilePath)
+					Ω(err).Should(BeNil())
+					Ω(expectedBytes).ShouldNot(BeNil())
+
+					actualBytes, err := ioutil.ReadFile(actualFilePath)
+					Ω(err).Should(BeNil())
+					Ω(actualBytes).ShouldNot(BeNil())
+
+					Ω(string(expectedBytes)).Should(Equal(string(actualBytes)))
+				})
 			})
 
-			AfterEach(func() {
-				RemoveAllFiles(
-					GetFilePath(filepath.Join(inputFilesPath, "reordered"), "en.all.json"),
-				)
-			})
+			Context("merging en files in input_files/reordered path", func() {
+				BeforeEach(func() {
+					session := Runi18n("merge-strings", "-v", "-d", filepath.Join(inputFilesPath, "reordered"), "--source-language", "en")
+					Ω(session.ExitCode()).Should(Equal(0))
+				})
 
-			It("creates an en.all.json keeping the stable order", func() {
-				expectedFilePath := GetFilePath(expectedFilesPath, "en.all.json")
-				actualFilePath := GetFilePath(filepath.Join(inputFilesPath, "reordered"), "en.all.json")
+				AfterEach(func() {
+					RemoveAllFiles(
+						GetFilePath(filepath.Join(inputFilesPath, "reordered"), "en.all.json"),
+					)
+				})
 
-				expectedBytes, err := ioutil.ReadFile(expectedFilePath)
-				Ω(err).Should(BeNil())
-				Ω(expectedBytes).ShouldNot(BeNil())
+				It("creates an en.all.json keeping the stable order", func() {
+					expectedFilePath := GetFilePath(expectedFilesPath, "en.all.json")
+					actualFilePath := GetFilePath(filepath.Join(inputFilesPath, "reordered"), "en.all.json")
 
-				actualBytes, err := ioutil.ReadFile(actualFilePath)
-				Ω(err).Should(BeNil())
-				Ω(actualBytes).ShouldNot(BeNil())
+					expectedBytes, err := ioutil.ReadFile(expectedFilePath)
+					Ω(err).Should(BeNil())
+					Ω(expectedBytes).ShouldNot(BeNil())
 
-				Ω(string(expectedBytes)).Should(Equal(string(actualBytes)))
+					actualBytes, err := ioutil.ReadFile(actualFilePath)
+					Ω(err).Should(BeNil())
+					Ω(actualBytes).ShouldNot(BeNil())
+
+					Ω(string(expectedBytes)).Should(Equal(string(actualBytes)))
+				})
 			})
 		})
 	})

--- a/integration/merge_strings/r_option_test.go
+++ b/integration/merge_strings/r_option_test.go
@@ -39,28 +39,57 @@ var _ = Describe("merge-strings -d dirName -r", func() {
 		expectedFilesPath = filepath.Join(fixturesPath, "r_option", "expected_output")
 	})
 
-	Context("can combine multiple language files per directory", func() {
-		BeforeEach(func() {
-			session := Runi18n("-c", "merge-strings", "-v", "-r", "-d", filepath.Join(inputFilesPath), "--source-language", "en")
-			Ω(session.ExitCode()).Should(Equal(0))
-		})
+	Context("Using legacy commands", func() {
+		Context("can combine multiple language files per directory", func() {
+			BeforeEach(func() {
+				session := Runi18n("-c", "merge-strings", "-v", "-r", "-d", filepath.Join(inputFilesPath), "--source-language", "en")
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
 
-		AfterEach(func() {
-			RemoveAllFiles(
-				GetFilePath(inputFilesPath, "en.all.json"),
-				GetFilePath(inputFilesPath+"/sub", "en.all.json"),
-			)
-		})
+			AfterEach(func() {
+				RemoveAllFiles(
+					GetFilePath(inputFilesPath, "en.all.json"),
+					GetFilePath(inputFilesPath+"/sub", "en.all.json"),
+				)
+			})
 
-		It("en.all.json contains translations from both files", func() {
-			CompareExpectedToGeneratedTraslationJson(
-				GetFilePath(expectedFilesPath, "en.all.json"),
-				GetFilePath(inputFilesPath, "en.all.json"),
-			)
-			CompareExpectedToGeneratedTraslationJson(
-				GetFilePath(expectedFilesPath+"/sub", "en.all.json"),
-				GetFilePath(inputFilesPath+"/sub", "en.all.json"),
-			)
+			It("en.all.json contains translations from both files", func() {
+				CompareExpectedToGeneratedTraslationJson(
+					GetFilePath(expectedFilesPath, "en.all.json"),
+					GetFilePath(inputFilesPath, "en.all.json"),
+				)
+				CompareExpectedToGeneratedTraslationJson(
+					GetFilePath(expectedFilesPath+"/sub", "en.all.json"),
+					GetFilePath(inputFilesPath+"/sub", "en.all.json"),
+				)
+			})
+		})
+	})
+
+	Context("Using cobra commands", func() {
+		Context("can combine multiple language files per directory", func() {
+			BeforeEach(func() {
+				session := Runi18n("merge-strings", "-v", "-r", "-d", filepath.Join(inputFilesPath), "--source-language", "en")
+				Ω(session.ExitCode()).Should(Equal(0))
+			})
+
+			AfterEach(func() {
+				RemoveAllFiles(
+					GetFilePath(inputFilesPath, "en.all.json"),
+					GetFilePath(inputFilesPath+"/sub", "en.all.json"),
+				)
+			})
+
+			It("en.all.json contains translations from both files", func() {
+				CompareExpectedToGeneratedTraslationJson(
+					GetFilePath(expectedFilesPath, "en.all.json"),
+					GetFilePath(inputFilesPath, "en.all.json"),
+				)
+				CompareExpectedToGeneratedTraslationJson(
+					GetFilePath(expectedFilesPath+"/sub", "en.all.json"),
+					GetFilePath(inputFilesPath+"/sub", "en.all.json"),
+				)
+			})
 		})
 	})
 

--- a/integration/show_missing_strings/d_option_test.go
+++ b/integration/show_missing_strings/d_option_test.go
@@ -40,45 +40,93 @@ var _ = Describe("show-missing-strings -d dirName", func() {
 		inputFilesPath = filepath.Join(fixturesPath, "d_option", "input_files")
 	})
 
-	Context("When all the translated strings are in the json resource", func() {
-		BeforeEach(func() {
-			languageFilePath := filepath.Join(inputFilesPath, "no_missing_strings", "app.go.en.json")
-			codeDirPath := filepath.Join(inputFilesPath, "no_missing_strings", "code")
-			session = Runi18n("-c", "show-missing-strings", "-d", codeDirPath, "--i18n-strings-filename", languageFilePath)
+	Context("Using legacy commands", func() {
 
-			Eventually(session.ExitCode()).Should(Equal(0))
+		Context("When all the translated strings are in the json resource", func() {
+			BeforeEach(func() {
+				languageFilePath := filepath.Join(inputFilesPath, "no_missing_strings", "app.go.en.json")
+				codeDirPath := filepath.Join(inputFilesPath, "no_missing_strings", "code")
+				session = Runi18n("-c", "show-missing-strings", "-d", codeDirPath, "--i18n-strings-filename", languageFilePath)
+
+				Eventually(session.ExitCode()).Should(Equal(0))
+			})
+
+			It("Should output nothing", func() {
+				Ω(session).Should(Say(""))
+			})
 		})
 
-		It("Should output nothing", func() {
-			Ω(session).Should(Say(""))
+		Context("When there are strings missing from the json resource", func() {
+			BeforeEach(func() {
+				languageFilePath := filepath.Join(inputFilesPath, "missing_strings", "app.go.en.json")
+				codeDirPath := filepath.Join(inputFilesPath, "missing_strings", "code")
+				session = Runi18n("-c", "show-missing-strings", "-d", codeDirPath, "--i18n-strings-filename", languageFilePath)
+
+				Eventually(session.ExitCode()).Should(Equal(1))
+			})
+
+			It("Should output something", func() {
+				Ω(session).Should(Say("Missing"))
+			})
+		})
+
+		Context("When there are extra strings in the resource file", func() {
+			BeforeEach(func() {
+				languageFilePath := filepath.Join(inputFilesPath, "extra_strings", "app.go.en.json")
+				codeDirPath := filepath.Join(inputFilesPath, "extra_strings", "code")
+				session = Runi18n("-c", "show-missing-strings", "-d", codeDirPath, "--i18n-strings-filename", languageFilePath)
+
+				Eventually(session.ExitCode()).Should(Equal(1))
+			})
+
+			It("Should output something", func() {
+				Ω(session).Should(Say("Additional"))
+			})
 		})
 	})
 
-	Context("When there are strings missing from the json resource", func() {
-		BeforeEach(func() {
-			languageFilePath := filepath.Join(inputFilesPath, "missing_strings", "app.go.en.json")
-			codeDirPath := filepath.Join(inputFilesPath, "missing_strings", "code")
-			session = Runi18n("-c", "show-missing-strings", "-d", codeDirPath, "--i18n-strings-filename", languageFilePath)
+	Context("Using cobra commands", func() {
 
-			Eventually(session.ExitCode()).Should(Equal(1))
+		Context("When all the translated strings are in the json resource", func() {
+			BeforeEach(func() {
+				languageFilePath := filepath.Join(inputFilesPath, "no_missing_strings", "app.go.en.json")
+				codeDirPath := filepath.Join(inputFilesPath, "no_missing_strings", "code")
+				session = Runi18n("show-missing-strings", "-d", codeDirPath, "--i18n-strings-filename", languageFilePath)
+
+				Eventually(session.ExitCode()).Should(Equal(0))
+			})
+
+			It("Should output nothing", func() {
+				Ω(session).Should(Say(""))
+			})
 		})
 
-		It("Should output something", func() {
-			Ω(session).Should(Say("Missing"))
+		Context("When there are strings missing from the json resource", func() {
+			BeforeEach(func() {
+				languageFilePath := filepath.Join(inputFilesPath, "missing_strings", "app.go.en.json")
+				codeDirPath := filepath.Join(inputFilesPath, "missing_strings", "code")
+				session = Runi18n("show-missing-strings", "-d", codeDirPath, "--i18n-strings-filename", languageFilePath)
+
+				Eventually(session.ExitCode()).Should(Equal(1))
+			})
+
+			It("Should output something", func() {
+				Ω(session).Should(Say("Missing"))
+			})
 		})
-	})
 
-	Context("When there are extra strings in the resource file", func() {
-		BeforeEach(func() {
-			languageFilePath := filepath.Join(inputFilesPath, "extra_strings", "app.go.en.json")
-			codeDirPath := filepath.Join(inputFilesPath, "extra_strings", "code")
-			session = Runi18n("-c", "show-missing-strings", "-d", codeDirPath, "--i18n-strings-filename", languageFilePath)
+		Context("When there are extra strings in the resource file", func() {
+			BeforeEach(func() {
+				languageFilePath := filepath.Join(inputFilesPath, "extra_strings", "app.go.en.json")
+				codeDirPath := filepath.Join(inputFilesPath, "extra_strings", "code")
+				session = Runi18n("show-missing-strings", "-d", codeDirPath, "--i18n-strings-filename", languageFilePath)
 
-			Eventually(session.ExitCode()).Should(Equal(1))
-		})
+				Eventually(session.ExitCode()).Should(Equal(1))
+			})
 
-		It("Should output something", func() {
-			Ω(session).Should(Say("Additional"))
+			It("Should output something", func() {
+				Ω(session).Should(Say("Additional"))
+			})
 		})
 	})
 })


### PR DESCRIPTION
# Context

The purpose of this PR is to refactor the `show-missing-strings` and `merge-strings` subcommands which will still maintain the existing behavior by using `-c` to invoke the command.

The framework for maintaining backwards compatibility ability is to use the cobra implementation when the `-c` flag is NOT present


https://github.com/maximilien/i18n4go/issues/92
