### PR TITLE
build(github-workflow): increased stale issue check to 90 days

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,7 +2,7 @@ name: Mark stale issues and pull requests
 
 on:
   schedule:
-  - cron: "30 1 * * *"
+  - cron: "60 1 * * *"
 
 jobs:
   stale:
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/stale@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue is staled for 30 days'
-        stale-pr-message: 'This PR is staled for 30 days'
+        stale-issue-message: 'This issue is staled for 60 days'
+        stale-pr-message: 'This PR is staled for 60 days'
         stale-issue-label: 'no-issue-activity'
         stale-pr-label: 'no-pr-activity'


### PR DESCRIPTION
# Context

30 days is a bit short to mark an issue stale. Changing the time to 90 days

Resolves: https://github.com/maximilien/i18n4go/issues/130
